### PR TITLE
Implement reqwest features: bearer_auth and form

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ libflate = { version = "0.1", optional = true }
 native-tls = { version = "0.2", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
+serde_urlencoded = { version = "0.6", optional = true }
 
 [dev-dependencies]
 env_logger = "0.5"
@@ -33,6 +34,7 @@ charsets = ["encoding_rs"]
 compress = ["libflate"]
 tls = ["native-tls"]
 json = ["serde", "serde_json"]
+form = ["serde", "serde_urlencoded"]
 default = ["compress", "tls"]
 
 [package.metadata.docs.rs]

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,9 @@ pub enum ErrorKind {
     /// JSON decoding/encoding error.
     #[cfg(feature = "json")]
     Json(serde_json::Error),
+    /// Form-URL encoding error.
+    #[cfg(feature = "form")]
+    UrlEncoded(serde_urlencoded::ser::Error),
     /// TLS error encountered while connecting to an https server.
     #[cfg(feature = "tls")]
     Tls(native_tls::Error),
@@ -99,6 +102,8 @@ impl Display for Error {
             TooManyRedirections => write!(w, "Too many redirections"),
             #[cfg(feature = "json")]
             Json(ref e) => write!(w, "Json Error: {}", e),
+            #[cfg(feature = "form")]
+            UrlEncoded(ref e) => write!(w, "URL Encoding Error: {}", e),
             #[cfg(feature = "tls")]
             Tls(ref e) => write!(w, "Tls Error: {}", e),
         }
@@ -120,6 +125,8 @@ impl StdError for Error {
             TooManyRedirections => "too many redirections",
             #[cfg(feature = "json")]
             Json(ref e) => e.description(),
+            #[cfg(feature = "form")]
+            UrlEncoded(ref e) => e.description(),
             #[cfg(feature = "tls")]
             Tls(ref e) => e.description(),
         }
@@ -163,6 +170,13 @@ impl From<native_tls::Error> for Error {
 impl From<serde_json::Error> for Error {
     fn from(err: serde_json::Error) -> Error {
         Error(Box::new(ErrorKind::Json(err)))
+    }
+}
+
+#[cfg(feature = "form")]
+impl From<serde_urlencoded::ser::Error> for Error {
+    fn from(err: serde_urlencoded::ser::Error) -> Error {
+        Error(Box::new(ErrorKind::UrlEncoded(err)))
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -236,6 +236,19 @@ impl RequestBuilder {
         Ok(self)
     }
 
+    /// Set the body of this request to be the URL-encoded representation of the given object.
+    ///
+    /// If the `Content-Type` header is unset, it will be set to `application/x-www-form-urlencoded`.
+    #[cfg(feature = "form")]
+    pub fn form<T: serde::Serialize>(mut self, value: &T) -> Result<RequestBuilder> {
+        self.body = serde_urlencoded::to_string(value)?.into_bytes();
+        self.headers
+            .entry(http::header::CONTENT_TYPE)
+            .unwrap()
+            .or_insert(HeaderValue::from_static("application/x-www-form-urlencoded"));
+        Ok(self)
+    }
+
     /// Set the maximum number of redirections this `Request` can perform.
     pub fn max_redirections(mut self, max_redirections: u32) -> RequestBuilder {
         self.max_redirections = max_redirections;

--- a/src/request.rs
+++ b/src/request.rs
@@ -193,6 +193,11 @@ impl RequestBuilder {
         Ok(self)
     }
 
+    /// Enable HTTP bearer authentication.
+    pub fn bearer_auth(self, token: impl Into<String>) -> RequestBuilder {
+        self.header(http::header::AUTHORIZATION, format!("Bearer {}", token.into()))
+    }
+
     /// Set the body of this request to be text.
     ///
     /// If the `Content-Type` header is unset, it will be set to `text/plain` and the carset to UTF-8.

--- a/test
+++ b/test
@@ -6,5 +6,6 @@ cargo test --all-features
 cargo test --no-default-features
 cargo test --no-default-features --features charsets
 cargo test --no-default-features --features compress
+cargo test --no-default-features --features form
 cargo test --no-default-features --features json
 cargo test --no-default-features --features tls


### PR DESCRIPTION
I'm interested in making it easier to use leaner HTTP clients like attohttpc instead of the huge dependencies pulled by reqwest, especially when async execution is not required. Attohttpc seems quite good for this since the API is very close to reqwest (by design?). While experimenting with this, I stumbled upon these two missing features:

RequestBuilder::bearer_auth, which is just a convenience method to set an Authorization header of a specific form.

RequestBuilder::form, which is quite similar to RequestBuilder::json, so I tried to keep my implementation as close to it as possible, including making it an optional feature.

I hope these additions will reduce the friction of switching from reqwset to attohttpc. Please review the code and let me know if you suggest any modifications.