### PR TITLE
Support HTTP basic auth via OpenSSL Base64 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ serde = { version = "1", optional = true }
 serde_json = { version = "1", optional = true }
 serde_urlencoded = { version = "0.6", optional = true }
 
+[target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
+openssl = { version = "0.10.26", optional = true }
+
 [dev-dependencies]
 env_logger = "0.7"
 lazy_static = "1"
@@ -32,7 +35,7 @@ rouille = "3"
 [features]
 charsets = ["encoding_rs"]
 compress = ["libflate"]
-tls = ["native-tls"]
+tls = ["native-tls", "openssl"]
 json = ["serde", "serde_json"]
 form = ["serde", "serde_urlencoded"]
 default = ["compress", "tls"]

--- a/src/request.rs
+++ b/src/request.rs
@@ -206,6 +206,24 @@ impl<B> RequestBuilder<B> {
         Ok(self)
     }
 
+    /// Enable HTTP basic authentication.
+    ///
+    /// This is available only on Linux and when TLS support is enabled.
+    #[cfg(all(
+        feature = "tls",
+        not(any(target_os = "windows", target_os = "macos", target_os = "ios"))
+    ))]
+    pub fn basic_auth(self, username: impl std::fmt::Display, password: Option<impl std::fmt::Display>) -> Self {
+        let auth = match password {
+            Some(password) => format!("{}:{}", username, password),
+            None => format!("{}:", username),
+        };
+        self.header(
+            http::header::AUTHORIZATION,
+            format!("Basic {}", openssl::base64::encode_block(auth.as_bytes())),
+        )
+    }
+
     /// Enable HTTP bearer authentication.
     pub fn bearer_auth(self, token: impl Into<String>) -> Self {
         self.header(http::header::AUTHORIZATION, format!("Bearer {}", token.into()))


### PR DESCRIPTION
OpenSSL provides TLS support on Unix platforms, but also includes Base64 encoding which allows us to support HTTP basic authentication without additional dependencies.