### PR TITLE
Update http dependency to current stable version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["http", "client", "tls"]
 categories = ["network-programming", "web-programming", "web-programming::http-client"]
 
 [dependencies]
-http = "0.1"
+http = "0.2"
 log = "0.4"
 url = "2"
 encoding_rs = { version = "0.8", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::error::Error as StdError;
 use std::fmt::{self, Display};
 use std::io;
@@ -147,6 +148,12 @@ impl StdError for Error {
     }
 }
 
+impl From<Infallible> for Error {
+    fn from(_err: Infallible) -> Error {
+        unreachable!()
+    }
+}
+
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
         Error(Box::new(ErrorKind::Io(err)))
@@ -156,6 +163,12 @@ impl From<io::Error> for Error {
 impl From<http::Error> for Error {
     fn from(err: http::Error) -> Error {
         Error(Box::new(ErrorKind::Http(err)))
+    }
+}
+
+impl From<http::header::InvalidHeaderValue> for Error {
+    fn from(err: http::header::InvalidHeaderValue) -> Error {
+        Error(Box::new(ErrorKind::Http(http::Error::from(err))))
     }
 }
 


### PR DESCRIPTION
The `http` recently saw a [new stable release](https://seanmonstar.com/post/189439210962/http-v02) and the ecosystem is expected to move there eventually.