### PR TITLE
Limit buffers::read_line method to avoid unchecked buffer allocations

### DIFF
--- a/src/parsing/buffers.rs
+++ b/src/parsing/buffers.rs
@@ -1,18 +1,18 @@
 use std::io::{self, BufRead, BufReader, Read};
 
-pub fn read_line<R>(reader: &mut BufReader<R>, buf: &mut Vec<u8>) -> io::Result<usize>
+pub fn read_line<R>(reader: &mut BufReader<R>, buf: &mut Vec<u8>, max_buf_len: u64) -> io::Result<usize>
 where
     R: Read,
 {
     buf.clear();
-    let n = reader.read_until(b'\n', buf)?;
+    let n = reader.take(max_buf_len).read_until(b'\n', buf)?;
 
     if buf.ends_with(b"\r\n") {
         buf.truncate(buf.len() - 2);
-    }
-
-    if buf.ends_with(b"\n") {
+    } else if buf.ends_with(b"\n") {
         buf.truncate(buf.len() - 1);
+    } else {
+        return Err(io::ErrorKind::UnexpectedEof.into());
     }
 
     Ok(n)
@@ -32,44 +32,56 @@ pub fn trim_byte_right(byte: u8, buf: &[u8]) -> &[u8] {
 
 #[test]
 fn test_read_line_lf() {
-    let mut reader = BufReader::new(&b"hello\nworld"[..]);
+    let mut reader = BufReader::new(&b"hello\nworld\n"[..]);
     let mut line = Vec::new();
 
-    assert_eq!(read_line(&mut reader, &mut line).ok(), Some(6));
+    assert_eq!(read_line(&mut reader, &mut line, u64::max_value()).ok(), Some(6));
     assert_eq!(line, b"hello");
 
-    assert_eq!(read_line(&mut reader, &mut line).ok(), Some(5));
+    assert_eq!(read_line(&mut reader, &mut line, u64::max_value()).ok(), Some(6));
     assert_eq!(line, b"world");
 }
 
 #[test]
 fn test_read_line_crlf() {
-    let mut reader = BufReader::new(&b"hello\r\nworld"[..]);
+    let mut reader = BufReader::new(&b"hello\r\nworld\r\n"[..]);
     let mut line = Vec::new();
 
-    assert_eq!(read_line(&mut reader, &mut line).ok(), Some(7));
+    assert_eq!(read_line(&mut reader, &mut line, u64::max_value()).ok(), Some(7));
     assert_eq!(line, b"hello");
 
-    assert_eq!(read_line(&mut reader, &mut line).ok(), Some(5));
+    assert_eq!(read_line(&mut reader, &mut line, u64::max_value()).ok(), Some(7));
     assert_eq!(line, b"world");
 }
 
 #[test]
-fn test_read_line_empty() {
-    let mut reader = BufReader::new(&b""[..]);
+fn test_read_line_empty_crlf() {
+    let mut reader = BufReader::new(&b"\r\n"[..]);
     let mut line = Vec::new();
 
-    assert_eq!(read_line(&mut reader, &mut line).ok(), Some(0));
+    assert_eq!(read_line(&mut reader, &mut line, u64::max_value()).ok(), Some(2));
     assert_eq!(line, b"");
 }
 
 #[test]
-fn test_read_line_empty_line() {
+fn test_read_line_empty_lf() {
     let mut reader = BufReader::new(&b"\n"[..]);
     let mut line = Vec::new();
 
-    assert_eq!(read_line(&mut reader, &mut line).ok(), Some(1));
+    assert_eq!(read_line(&mut reader, &mut line, u64::max_value()).ok(), Some(1));
     assert_eq!(line, b"");
+}
+
+#[test]
+fn test_read_line_beyond_limit() {
+    let mut reader = BufReader::new(&b"1234567890\n"[..]);
+    let mut line = Vec::new();
+
+    assert_eq!(
+        read_line(&mut reader, &mut line, 5).unwrap_err().kind(),
+        io::ErrorKind::UnexpectedEof
+    );
+    assert_eq!(line, b"12345");
 }
 
 #[test]

--- a/src/parsing/chunked_reader.rs
+++ b/src/parsing/chunked_reader.rs
@@ -48,7 +48,7 @@ where
 
     #[inline]
     fn read_line(&mut self) -> io::Result<usize> {
-        buffers::read_line(&mut self.inner, &mut self.line)
+        buffers::read_line(&mut self.inner, &mut self.line, 128)
     }
 
     fn read_chunk_size(&mut self) -> io::Result<u64> {
@@ -171,7 +171,7 @@ fn test_read_invalid_no_terminating_chunk() {
     let mut s = String::new();
     assert_eq!(
         reader.read_to_string(&mut s).err().unwrap().kind(),
-        io::ErrorKind::Other
+        io::ErrorKind::UnexpectedEof
     );
 }
 
@@ -182,6 +182,6 @@ fn test_read_invalid_bad_terminating_chunk() {
     let mut s = String::new();
     assert_eq!(
         reader.read_to_string(&mut s).err().unwrap().kind(),
-        io::ErrorKind::Other
+        io::ErrorKind::UnexpectedEof
     );
 }

--- a/src/parsing/response.rs
+++ b/src/parsing/response.rs
@@ -22,12 +22,14 @@ pub fn parse_response_head<R>(reader: &mut BufReader<R>) -> Result<(StatusCode, 
 where
     R: Read,
 {
+    const MAX_LINE_LEN: u64 = 16 * 1024;
+
     let mut line = Vec::new();
     let mut headers = HeaderMap::new();
 
     // status line
     let status: StatusCode = {
-        buffers::read_line(reader, &mut line)?;
+        buffers::read_line(reader, &mut line, MAX_LINE_LEN)?;
         let mut parts = line.split(|&b| b == b' ').filter(|x| !x.is_empty());
 
         let _ = parts.next().ok_or(InvalidResponseKind::StatusLine)?;
@@ -40,7 +42,7 @@ where
     };
 
     loop {
-        buffers::read_line(reader, &mut line)?;
+        buffers::read_line(reader, &mut line, MAX_LINE_LEN)?;
         if line.is_empty() {
             break;
         }


### PR DESCRIPTION
This makes buffers::read_line stricter in two ways: We limit the amount of data read and hence the amount of buffers allocated for a single line. And we actually expect to read a line ending instead of potentially just hitting EOF as we really always parse full lines in HTTP.

For now this mainly applies to the status and header lines as well as the chunk sizes for chunked transfer encoding.

Closes #24