### PR TITLE
Replace home grown TextReader with usage of encoding_rs_io crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ http = "0.2"
 log = "0.4"
 url = "2"
 encoding_rs = { version = "0.8", optional = true }
+encoding_rs_io = { version = "0.1", optional = true }
 flate2 = { version = "1.0", optional = true }
 native-tls = { version = "0.2", optional = true }
 serde = { version = "1", optional = true }
@@ -33,7 +34,7 @@ lazy_static = "1"
 rouille = "3"
 
 [features]
-charsets = ["encoding_rs"]
+charsets = ["encoding_rs", "encoding_rs_io"]
 compress = ["flate2"]
 tls = ["native-tls", "openssl"]
 json = ["serde", "serde_json"]
@@ -67,3 +68,8 @@ required-features = ["json"]
 name = "post"
 path = "examples/post.rs"
 required-features = ["tls"]
+
+[[example]]
+name = "charset"
+path = "examples/charset.rs"
+required-features = ["charsets"]

--- a/examples/charset.rs
+++ b/examples/charset.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), attohttpc::Error> {
+    env_logger::init();
+
+    let resp = attohttpc::get("https://rust-lang.org/").send()?;
+    println!("{}", resp.text()?);
+    Ok(())
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -21,7 +21,7 @@ use crate::error::{Error, ErrorKind, InvalidResponseKind, Result};
 use crate::parsing::{parse_response, Response};
 use crate::streams::BaseStream;
 
-const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn header_insert<H, V>(headers: &mut HeaderMap, header: H, value: V) -> Result
 where


### PR DESCRIPTION
Considering the dependency is behind a feature and adds little code on top of encoding_rs, it seems reasonable to avoid the duplication. (And rather collaborate upstream if we need modifications to `DecodeBytesReader`.)

Closes #32 