### PR TITLE
Extend RequestBuilder to support specifying timeouts

### DIFF
--- a/src/happy.rs
+++ b/src/happy.rs
@@ -5,7 +5,6 @@ use std::sync::mpsc::channel;
 use std::thread;
 use std::time::{Duration, Instant};
 
-const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 const RACE_DELAY: Duration = Duration::from_millis(200);
 
 /// This function implements a basic form of the happy eyeballs RFC to quickly connect
@@ -13,11 +12,10 @@ const RACE_DELAY: Duration = Duration::from_millis(200);
 /// against each other and the first to connect successfully wins the race.
 ///
 /// If the timeout is not provided, a default timeout of 10 seconds is used.
-pub fn connect<A>(addrs: A, timeout: impl Into<Option<Duration>>) -> io::Result<TcpStream>
+pub fn connect<A>(addrs: A, timeout: Duration) -> io::Result<TcpStream>
 where
     A: ToSocketAddrs,
 {
-    let timeout = timeout.into().unwrap_or(DEFAULT_CONNECTION_TIMEOUT);
     let addrs: Vec<_> = addrs.to_socket_addrs()?.collect();
 
     if let [addr] = &addrs[..] {

--- a/tests/test_timeout.rs
+++ b/tests/test_timeout.rs
@@ -1,0 +1,31 @@
+use std::io;
+use std::net::TcpListener;
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn request_fails_due_to_read_timeout() {
+    let listener = TcpListener::bind("localhost:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let thread = thread::spawn(move || {
+        let _stream = listener.accept().unwrap();
+        thread::sleep(Duration::from_millis(500));
+    });
+
+    let result = attohttpc::get(format!("http://localhost:{}", port))
+        .read_timeout(Duration::from_millis(100))
+        .send();
+
+    match result {
+        Err(err) => match err.kind() {
+            attohttpc::ErrorKind::Io(err) => match err.kind() {
+                io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock => (),
+                err => panic!("Unexpected I/O error: {:?}", err),
+            },
+            err => panic!("Unexpected error: {:?}", err),
+        },
+        Ok(resp) => panic!("Unexpected response: {:?}", resp),
+    }
+
+    thread.join().unwrap();
+}


### PR DESCRIPTION
We expose the connect and read timeouts of the underlying TCP connection and provide reasonable defaults.

Related to #35 but not closing it as it adds a read timeout, a not a request timeout.