### PR TITLE
Only try to redirect for whitelisted status codes

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use http::header::ACCEPT_ENCODING;
 use http::{
     header::{HeaderValue, IntoHeaderName, ACCEPT, CONNECTION, CONTENT_LENGTH, HOST, USER_AGENT},
-    HeaderMap, Method, Version,
+    HeaderMap, Method, StatusCode, Version,
 };
 use url::Url;
 
@@ -624,7 +624,15 @@ impl<B: AsRef<[u8]>> PreparedRequest<B> {
 
             debug!("status code {}", resp.status().as_u16());
 
-            if !self.follow_redirects || !resp.status().is_redirection() {
+            let is_redirect = match resp.status() {
+                StatusCode::MOVED_PERMANENTLY
+                | StatusCode::FOUND
+                | StatusCode::SEE_OTHER
+                | StatusCode::TEMPORARY_REDIRECT
+                | StatusCode::PERMANENT_REDIRECT => true,
+                _ => false,
+            };
+            if !self.follow_redirects || !is_redirect {
                 return Ok(resp);
             }
 

--- a/tests/test_redirection.rs
+++ b/tests/test_redirection.rs
@@ -1,6 +1,4 @@
-use std::net::TcpStream;
 use std::thread;
-use std::time::{Duration, Instant};
 
 use attohttpc::ErrorKind;
 use lazy_static::lazy_static;
@@ -15,18 +13,6 @@ lazy_static! {
         )).unwrap();
         let port = server.server_addr().port();
         thread::spawn(|| { server.run(); });
-
-        let start = Instant::now();
-        let timeout = Duration::from_secs(10);
-
-        // Wait until server is ready. 10s timeout in case of error creating server.
-        while TcpStream::connect(("localhost", port)).is_err() {
-            if start.elapsed() > timeout {
-                panic!("time out in server creation");
-            }
-            thread::sleep(Duration::from_millis(100));
-        }
-
         port
     };
 }


### PR DESCRIPTION
The current version of attohttpc tries to redirect for any 3xx status code. However, not all such status codes indicate an automatically processable redirect. Instead, only try to redirect for whitelisted status codes.

Fixes #30. Fixes #45.