### PR TITLE
Support generic bodies using a dedicated trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ mod streams;
 
 pub use crate::error::{Error, ErrorKind, InvalidResponseKind, Result};
 pub use crate::parsing::{Response, ResponseReader};
-pub use crate::request::{PreparedRequest, RequestBuilder, Session};
+pub use crate::request::{body, PreparedRequest, RequestBuilder, Session};
 #[cfg(feature = "charsets")]
 pub use crate::{charsets::Charset, parsing::TextReader};
 pub use http::Method;

--- a/src/request/body.rs
+++ b/src/request/body.rs
@@ -1,0 +1,64 @@
+use std::convert::TryInto;
+use std::io::{Result as IoResult, Write};
+
+/// The kinds of request bodies currently supported by this crate.
+#[derive(Debug, Clone, Copy)]
+pub enum BodyKind {
+    /// An empty request body
+    Empty,
+    /// A request body with a known length
+    KnownLength(u64),
+}
+
+/// A generic rewindable request body
+pub trait Body {
+    /// Determine the kind of the request body
+    fn kind(&mut self) -> IoResult<BodyKind>;
+
+    /// Write out the request body into the given writer
+    fn write<W: Write>(&mut self, writer: W) -> IoResult<()>;
+}
+
+/// An empty request body
+#[derive(Debug, Clone, Copy)]
+pub struct Empty;
+
+impl Body for Empty {
+    fn kind(&mut self) -> IoResult<BodyKind> {
+        Ok(BodyKind::Empty)
+    }
+
+    fn write<W: Write>(&mut self, _writer: W) -> IoResult<()> {
+        Ok(())
+    }
+}
+
+/// A request body containing UTF-8-encoded text
+#[derive(Debug, Clone)]
+pub struct Text<B>(pub B);
+
+impl<B: AsRef<str>> Body for Text<B> {
+    fn kind(&mut self) -> IoResult<BodyKind> {
+        let len = self.0.as_ref().len().try_into().unwrap();
+        Ok(BodyKind::KnownLength(len))
+    }
+
+    fn write<W: Write>(&mut self, mut writer: W) -> IoResult<()> {
+        writer.write_all(self.0.as_ref().as_bytes())
+    }
+}
+
+/// A request body containing binary data
+#[derive(Debug, Clone)]
+pub struct Bytes<B>(pub B);
+
+impl<B: AsRef<[u8]>> Body for Bytes<B> {
+    fn kind(&mut self) -> IoResult<BodyKind> {
+        let len = self.0.as_ref().len().try_into().unwrap();
+        Ok(BodyKind::KnownLength(len))
+    }
+
+    fn write<W: Write>(&mut self, mut writer: W) -> IoResult<()> {
+        writer.write_all(self.0.as_ref())
+    }
+}

--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -1,5 +1,6 @@
 use std::borrow::Borrow;
 use std::convert::{From, TryInto};
+use std::fs;
 use std::str;
 #[cfg(feature = "tls-rustls")]
 use std::sync::Arc;
@@ -173,6 +174,17 @@ impl<B> RequestBuilder<B> {
             .entry(http::header::CONTENT_TYPE)
             .or_insert(HeaderValue::from_static("application/octet-stream"));
         self.body(body::Bytes(body))
+    }
+
+    /// Set the body of this request using a local file.
+    ///
+    /// If the `Content-Type` header is unset, it will be set to `application/octet-stream`.
+    pub fn file(mut self, body: fs::File) -> RequestBuilder<impl Body> {
+        self.base_settings
+            .headers
+            .entry(http::header::CONTENT_TYPE)
+            .or_insert(HeaderValue::from_static("application/octet-stream"));
+        self.body(body::File(body))
     }
 
     /// Set the body of this request to be the JSON representation of the given object.

--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -145,7 +145,7 @@ impl<B> RequestBuilder<B> {
         self.header(http::header::AUTHORIZATION, format!("Bearer {}", token.into()))
     }
 
-    fn body(self, body: impl Body) -> RequestBuilder<impl Body> {
+    fn body<B1: Body>(self, body: B1) -> RequestBuilder<B1> {
         RequestBuilder {
             url: self.url,
             method: self.method,
@@ -157,7 +157,7 @@ impl<B> RequestBuilder<B> {
     /// Set the body of this request to be text.
     ///
     /// If the `Content-Type` header is unset, it will be set to `text/plain` and the carset to UTF-8.
-    pub fn text(mut self, body: impl AsRef<str>) -> RequestBuilder<impl Body> {
+    pub fn text<B1: AsRef<str>>(mut self, body: B1) -> RequestBuilder<body::Text<B1>> {
         self.base_settings
             .headers
             .entry(http::header::CONTENT_TYPE)
@@ -168,7 +168,7 @@ impl<B> RequestBuilder<B> {
     /// Set the body of this request to be bytes.
     ///
     /// If the `Content-Type` header is unset, it will be set to `application/octet-stream`.
-    pub fn bytes(mut self, body: impl AsRef<[u8]>) -> RequestBuilder<impl Body> {
+    pub fn bytes<B1: AsRef<[u8]>>(mut self, body: B1) -> RequestBuilder<body::Bytes<B1>> {
         self.base_settings
             .headers
             .entry(http::header::CONTENT_TYPE)
@@ -179,7 +179,7 @@ impl<B> RequestBuilder<B> {
     /// Set the body of this request using a local file.
     ///
     /// If the `Content-Type` header is unset, it will be set to `application/octet-stream`.
-    pub fn file(mut self, body: fs::File) -> RequestBuilder<impl Body> {
+    pub fn file(mut self, body: fs::File) -> RequestBuilder<body::File> {
         self.base_settings
             .headers
             .entry(http::header::CONTENT_TYPE)

--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -145,7 +145,11 @@ impl<B> RequestBuilder<B> {
         self.header(http::header::AUTHORIZATION, format!("Bearer {}", token.into()))
     }
 
-    fn body<B1: Body>(self, body: B1) -> RequestBuilder<B1> {
+    /// Set the body of this request.
+    ///
+    /// The [BodyKind enum](crate::body::BodyKind) and [Body trait](crate::body::Body)
+    /// determine how to implement custom request body types.
+    pub fn body<B1: Body>(self, body: B1) -> RequestBuilder<B1> {
         RequestBuilder {
             url: self.url,
             method: self.method,


### PR DESCRIPTION
This adds the `body` module to generically describe rewindable bodies which is the first step towards resolving #55. (We still need to implement a chunked transfer encoding writer to fully support streaming bodies, but that can be done as a follow-up change.)