### PR TITLE
Optional multipart support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ openssl = { version = "0.10.26", optional = true }
 env_logger = "0.7"
 lazy_static = "1"
 rouille = "3"
+warp = "0.2.3"
+tokio = { version = "0.2.21", features = ["io-driver", "time", "rt-threaded"] }
 
 [features]
 charsets = ["encoding_rs", "encoding_rs_io"]
@@ -90,3 +92,8 @@ required-features = ["multipart-form"]
 name = "test_invalid_certs"
 path = "tests/test_invalid_certs.rs"
 required-features = ["tls"]
+
+[[test]]
+name = "test_multipart"
+path = "tests/test_multipart.rs"
+required-features = ["multipart-form"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ serde_json = { version = "1", optional = true }
 serde_urlencoded = { version = "0.6", optional = true }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.19", optional = true }
+multipart = { version = "0.16.1", optional = true }
+mime = { version = "0.2", optional = true }
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 openssl = { version = "0.10.26", optional = true }
@@ -44,6 +46,7 @@ tls-rustls = ["rustls", "webpki", "webpki-roots"]
 json = ["serde", "serde_json"]
 form = ["serde", "serde_urlencoded"]
 default = ["compress", "tls"]
+multipart-form = ["multipart", "mime"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -77,6 +80,11 @@ required-features = ["tls"]
 name = "charset"
 path = "examples/charset.rs"
 required-features = ["charsets"]
+
+[[example]]
+name = "multipart"
+path = "examples/multipart.rs"
+required-features = ["multipart-form"]
 
 [[test]]
 name = "test_invalid_certs"

--- a/examples/multipart.rs
+++ b/examples/multipart.rs
@@ -1,0 +1,19 @@
+fn main() -> attohttpc::Result {
+    env_logger::init();
+
+    let file = attohttpc::MultipartFile::new("file", b"Hello, world!")
+        .with_type("text/plain")?
+        .with_filename("hello.txt");
+    let form = attohttpc::MultipartBuilder::new()
+        .with_text("Hello", "world!")
+        .with_file(file)
+        .build()?;
+
+    let resp = attohttpc::post("http://httpbin.org/post").body(form).send()?;
+
+    println!("Status: {:?}", resp.status());
+    println!("Headers:\n{:#?}", resp.headers());
+    println!("Body:\n{}", resp.text()?);
+
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,11 +75,13 @@ pub enum ErrorKind {
     /// Invalid DNS name used for TLS certificate verification
     #[cfg(feature = "tls-rustls")]
     InvalidDNSName(webpki::InvalidDNSNameError),
+    /// Invalid mime type in a Multipart form
+    InvalidMimeType(String),
 }
 
 /// A type that contains all the errors that can possibly occur while accessing an HTTP server.
 #[derive(Debug)]
-pub struct Error(Box<ErrorKind>);
+pub struct Error(pub(crate) Box<ErrorKind>);
 
 impl Error {
     /// Get a reference to the `ErrorKind` inside.
@@ -115,6 +117,7 @@ impl Display for Error {
             Tls(ref e) => write!(w, "Tls Error: {}", e),
             #[cfg(feature = "tls-rustls")]
             InvalidDNSName(ref e) => write!(w, "Invalid DNS name: {}", e),
+            InvalidMimeType(ref e) => write!(w, "Invalid mime type: {}", e),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 //! * `form` support for url encoded forms (does not include support for multipart)
 //! * `tls` support for tls connections (**default**)
 //! * `tls-rustls` support for TLS connections using `rustls` instead of `native-tls`
+//! * `multipart-form` support for multipart forms (does not include support for url encoding)
 //!
 //! # Activating a feature
 //! To activate a feature, specify it in your `Cargo.toml` file like so

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,11 +59,15 @@ extern crate log;
 pub mod charsets;
 mod error;
 mod happy;
+#[cfg(feature = "multipart")]
+mod multipart;
 mod parsing;
 mod request;
 mod streams;
 
 pub use crate::error::{Error, ErrorKind, InvalidResponseKind, Result};
+#[cfg(feature = "multipart")]
+pub use crate::multipart::{Multipart, MultipartBuilder, MultipartFile};
 pub use crate::parsing::{Response, ResponseReader};
 pub use crate::request::{body, PreparedRequest, RequestBuilder, RequestInspector, Session};
 #[cfg(feature = "charsets")]

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -1,0 +1,123 @@
+use super::body::{Body, BodyKind};
+use super::{Error, ErrorKind, Result};
+use mime::Mime;
+use multipart::client as mp;
+use std::fmt;
+use std::io::{copy, prelude::*, Cursor, Error as IoError, Result as IoResult};
+
+/// A file to be uploaded as part of a multipart form.
+#[derive(Debug, Clone)]
+pub struct MultipartFile {
+    name: String,
+    file: Vec<u8>,
+    filename: Option<String>,
+    mime: Option<Mime>,
+}
+
+impl MultipartFile {
+    /// Constructs a new `MultipartFile` from the name and contents.
+    pub fn new(name: impl AsRef<str>, file: impl AsRef<[u8]>) -> Self {
+        let name = name.as_ref().to_owned();
+        let file = file.as_ref().to_owned();
+        Self {
+            name,
+            file,
+            filename: None,
+            mime: None,
+        }
+    }
+
+    /// Sets the MIME type of the file.
+    ///
+    /// # Errors
+    /// Returns an error if the MIME type is invalid.
+    pub fn with_type(self, mime_type: impl AsRef<str>) -> Result<Self> {
+        let mime_str = mime_type.as_ref();
+        let mime: Mime = match mime_str.parse() {
+            Ok(mime) => mime,
+            Err(()) => return Err(Error(Box::new(ErrorKind::InvalidMimeType(mime_str.to_string())))),
+        };
+        Ok(Self {
+            mime: Some(mime),
+            ..self
+        })
+    }
+
+    /// Sets the filename of the file.
+    pub fn with_filename(self, filename: impl AsRef<str>) -> Self {
+        Self {
+            filename: Some(filename.as_ref().to_owned()),
+            ..self
+        }
+    }
+}
+
+/// A builder for creating a `Multipart` body.
+#[derive(Debug, Clone, Default)]
+pub struct MultipartBuilder {
+    text: Vec<(String, String)>,
+    files: Vec<MultipartFile>,
+}
+
+impl MultipartBuilder {
+    /// Creates a new `MultipartBuilder`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a text field to the form.
+    pub fn with_text(mut self, name: impl AsRef<str>, text: impl AsRef<str>) -> Self {
+        let name = name.as_ref().to_string();
+        let text = text.as_ref().to_string();
+        self.text.push((name, text));
+        self
+    }
+
+    /// Adds a `MultipartFile` to the form.
+    pub fn with_file(mut self, file: MultipartFile) -> Self {
+        self.files.push(file);
+        self
+    }
+
+    /// Creates a `Multipart` to be used as a body.
+    pub fn build(self) -> Result<Multipart> {
+        let mut mp = mp::lazy::Multipart::new();
+        for (k, v) in self.text {
+            mp.add_text(k, v);
+        }
+        for file in self.files {
+            mp.add_stream(file.name, Cursor::new(file.file), file.filename, file.mime);
+        }
+        let prepared = mp.prepare().map_err::<IoError, _>(Into::into)?;
+        Ok(Multipart { data: prepared })
+    }
+}
+
+/// A multipart form created using `MultipartBuilder`.
+pub struct Multipart {
+    data: mp::lazy::PreparedFields<'static>,
+}
+
+impl Body for Multipart {
+    fn kind(&mut self) -> IoResult<BodyKind> {
+        match self.data.content_len() {
+            Some(len) => Ok(BodyKind::KnownLength(len)),
+            None => Ok(BodyKind::Chunked),
+        }
+    }
+
+    fn write<W: Write>(&mut self, mut writer: W) -> IoResult<()> {
+        copy(&mut self.data, &mut writer)?;
+        Ok(())
+    }
+
+    fn content_type(&mut self) -> IoResult<Option<String>> {
+        Ok(Some(format!("multipart/form-data; boundary={}", self.data.boundary())))
+    }
+}
+
+impl fmt::Debug for Multipart {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Multipart").finish()
+    }
+}

--- a/src/request/body.rs
+++ b/src/request/body.rs
@@ -22,6 +22,11 @@ pub trait Body {
     ///
     /// This method can be called multiple times if a request is redirected.
     fn write<W: Write>(&mut self, writer: W) -> IoResult<()>;
+
+    /// Gets the content type this body is tied to if it has one.
+    fn content_type(&mut self) -> IoResult<Option<String>> {
+        Ok(None)
+    }
 }
 
 /// An empty request body

--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -8,7 +8,8 @@ use std::time::Duration;
 
 use http::{
     header::{
-        HeaderMap, HeaderValue, IntoHeaderName, ACCEPT, CONNECTION, CONTENT_LENGTH, TRANSFER_ENCODING, USER_AGENT,
+        HeaderMap, HeaderValue, IntoHeaderName, ACCEPT, CONNECTION, CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING,
+        USER_AGENT,
     },
     Method,
 };
@@ -419,6 +420,10 @@ impl<B: Body> RequestBuilder<B> {
             BodyKind::Chunked => {
                 header_insert(&mut prepped.base_settings.headers, TRANSFER_ENCODING, "chunked")?;
             }
+        }
+
+        if let Some(typ) = prepped.body.content_type()? {
+            header_insert(&mut prepped.base_settings.headers, CONTENT_TYPE, typ)?;
         }
 
         header_insert_if_missing(&mut prepped.base_settings.headers, ACCEPT, "*/*")?;

--- a/tests/test_multipart.rs
+++ b/tests/test_multipart.rs
@@ -22,7 +22,7 @@ fn start_server() -> (u16, Receiver<Option<String>>) {
                 .and_then(|ct: Mime| async move {
                     ct.get_param("boundary")
                         .map(ToString::to_string)
-                        .ok_or_else(|| warp::reject::reject())
+                        .ok_or_else(warp::reject::reject)
                 })
                 .and(warp::body::bytes())
                 .map(|boundary, bytes| Multipart::with_body(Cursor::new(bytes), boundary)),

--- a/tests/test_multipart.rs
+++ b/tests/test_multipart.rs
@@ -1,0 +1,73 @@
+use lazy_static::lazy_static;
+use mime::Mime;
+use multipart::server::Multipart;
+use std::io::{Cursor, Read};
+use std::net::SocketAddr;
+use std::thread;
+use tokio::runtime::Builder;
+use warp::Filter;
+
+lazy_static! {
+    static ref STARTED: u16 = {
+        let mut rt = Builder::new()
+            .enable_io()
+            .enable_time()
+            .threaded_scheduler()
+            .build()
+            .unwrap();
+        // ported from warp::multipart, which has a length limit (and we're generic over Read)
+        let filter = warp::path("multipart").and(warp::header::<Mime>("content-type").and_then(|ct: Mime| async move {
+            ct
+                .get_param("boundary")
+                .map(ToString::to_string)
+                .ok_or_else(|| warp::reject::reject())
+        }).and(warp::body::bytes()).map(|boundary, bytes| {
+            Multipart::with_body(Cursor::new(bytes), boundary)
+        })).map(|mut form: Multipart<_>| {
+            let mut found_text = false;
+            let mut found_file = false;
+            let mut buf = String::new();
+            form.foreach_entry(|mut entry| {
+                entry.data.read_to_string(&mut buf).unwrap();
+                if !found_text && &*entry.headers.name == "Hello" && buf == "world!" {
+                    found_text = true;
+                } else if !found_file && &*entry.headers.name == "file" && entry.headers.filename.as_deref() == Some("hello.txt") && entry.headers.content_type.as_ref().map(|x| x.to_string() == "text/plain") == Some(true) && buf == "Hello, world!" {
+                    found_file = true;
+                } else {
+                    panic!("Unexpected entry {:?} = {:?}", entry.headers, buf);
+                }
+                buf.clear();
+            }).unwrap();
+            assert!(found_text);
+            assert!(found_file);
+            "OK"
+        });
+        let (addr, fut) =
+            rt.block_on(async { warp::serve(filter).bind_ephemeral("0.0.0.0:0".parse::<SocketAddr>().unwrap()) });
+        let port = addr.port();
+        thread::spawn(move || {
+            rt.block_on(fut);
+        });
+        port
+    };
+}
+
+#[test]
+fn test_multipart_default() -> attohttpc::Result<()> {
+    let file = attohttpc::MultipartFile::new("file", b"Hello, world!")
+        .with_type("text/plain")?
+        .with_filename("hello.txt");
+    let form = attohttpc::MultipartBuilder::new()
+        .with_text("Hello", "world!")
+        .with_file(file)
+        .build()?;
+
+    let port = *STARTED;
+
+    attohttpc::post(format!("http://localhost:{}/multipart", port))
+        .body(form)
+        .send()?
+        .text()?;
+
+    Ok(())
+}

--- a/tests/test_multipart.rs
+++ b/tests/test_multipart.rs
@@ -1,55 +1,89 @@
-use lazy_static::lazy_static;
 use mime::Mime;
 use multipart::server::Multipart;
 use std::io::{Cursor, Read};
 use std::net::SocketAddr;
+use std::sync::mpsc::{sync_channel, Receiver};
 use std::thread;
 use tokio::runtime::Builder;
 use warp::Filter;
 
-lazy_static! {
-    static ref STARTED: u16 = {
-        let mut rt = Builder::new()
-            .enable_io()
-            .enable_time()
-            .threaded_scheduler()
-            .build()
-            .unwrap();
-        // ported from warp::multipart, which has a length limit (and we're generic over Read)
-        let filter = warp::path("multipart").and(warp::header::<Mime>("content-type").and_then(|ct: Mime| async move {
-            ct
-                .get_param("boundary")
-                .map(ToString::to_string)
-                .ok_or_else(|| warp::reject::reject())
-        }).and(warp::body::bytes()).map(|boundary, bytes| {
-            Multipart::with_body(Cursor::new(bytes), boundary)
-        })).map(|mut form: Multipart<_>| {
+fn start_server() -> (u16, Receiver<Option<String>>) {
+    let (send, recv) = sync_channel(1);
+    let mut rt = Builder::new()
+        .enable_io()
+        .enable_time()
+        .threaded_scheduler()
+        .build()
+        .unwrap();
+    // ported from warp::multipart, which has a length limit (and we're generic over Read)
+    let filter = warp::path("multipart")
+        .and(
+            warp::header::<Mime>("content-type")
+                .and_then(|ct: Mime| async move {
+                    ct.get_param("boundary")
+                        .map(ToString::to_string)
+                        .ok_or_else(|| warp::reject::reject())
+                })
+                .and(warp::body::bytes())
+                .map(|boundary, bytes| Multipart::with_body(Cursor::new(bytes), boundary)),
+        )
+        .map(move |mut form: Multipart<_>| {
             let mut found_text = false;
             let mut found_file = false;
+            let mut err = false;
             let mut buf = String::new();
             form.foreach_entry(|mut entry| {
+                if err {
+                    return;
+                }
                 entry.data.read_to_string(&mut buf).unwrap();
                 if !found_text && &*entry.headers.name == "Hello" && buf == "world!" {
                     found_text = true;
-                } else if !found_file && &*entry.headers.name == "file" && entry.headers.filename.as_deref() == Some("hello.txt") && entry.headers.content_type.as_ref().map(|x| x.to_string() == "text/plain") == Some(true) && buf == "Hello, world!" {
+                } else if !found_file
+                    && &*entry.headers.name == "file"
+                    && entry.headers.filename.as_deref() == Some("hello.txt")
+                    && entry
+                        .headers
+                        .content_type
+                        .as_ref()
+                        .map(|x| x.to_string() == "text/plain")
+                        == Some(true)
+                    && buf == "Hello, world!"
+                {
                     found_file = true;
                 } else {
-                    panic!("Unexpected entry {:?} = {:?}", entry.headers, buf);
+                    send.send(Some(format!("Unexpected entry {:?} = {:?}", entry.headers, buf)))
+                        .unwrap();
+                    err = true;
                 }
                 buf.clear();
-            }).unwrap();
-            assert!(found_text);
-            assert!(found_file);
-            "OK"
+            })
+            .unwrap();
+            if err {
+                return "ERR";
+            }
+            send.send(Some(
+                match (found_text, found_file) {
+                    (false, false) => "Missing both fields!",
+                    (true, false) => "Missing file field!",
+                    (false, true) => "Missing text field!",
+                    (true, true) => {
+                        send.send(None).unwrap();
+                        return "OK";
+                    }
+                }
+                .to_string(),
+            ))
+            .unwrap();
+            "ERR"
         });
-        let (addr, fut) =
-            rt.block_on(async { warp::serve(filter).bind_ephemeral("0.0.0.0:0".parse::<SocketAddr>().unwrap()) });
-        let port = addr.port();
-        thread::spawn(move || {
-            rt.block_on(fut);
-        });
-        port
-    };
+    let (addr, fut) =
+        rt.block_on(async { warp::serve(filter).bind_ephemeral("0.0.0.0:0".parse::<SocketAddr>().unwrap()) });
+    let port = addr.port();
+    thread::spawn(move || {
+        rt.block_on(fut);
+    });
+    (port, recv)
 }
 
 #[test]
@@ -62,12 +96,16 @@ fn test_multipart_default() -> attohttpc::Result<()> {
         .with_file(file)
         .build()?;
 
-    let port = *STARTED;
+    let (port, recv) = start_server();
 
     attohttpc::post(format!("http://localhost:{}/multipart", port))
         .body(form)
         .send()?
         .text()?;
+
+    if let Some(err) = recv.recv().unwrap() {
+        panic!("{}", err);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
I used the `multipart` crate for this, which doesn't seem to have been updated in over a year. However, there aren't any outstanding issues, and I couldn't find any other synchronous implementation that's not tied to a specific HTTP stack.