### PR TITLE
Fix the header_append documentation

### DIFF
--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -250,10 +250,9 @@ impl<B> RequestBuilder<B> {
         self.try_header(header, value).expect("invalid header value")
     }
 
-    /// Modify a header for this request.
+    /// Append a new header for this request.
     ///
-    /// If the header is already present, the value will be replaced. If you wish to append a new header,
-    /// use `header_append`.
+    /// The new header is always appended to the request, even if the header already exists.
     ///
     /// # Panics
     /// This method will panic if the value is invalid.

--- a/src/request/session.rs
+++ b/src/request/session.rs
@@ -114,10 +114,9 @@ impl Session {
         self.try_header(header, value).expect("invalid header value");
     }
 
-    /// Modify a header for this `Request`.
+    /// Append a new header for this `Request`.
     ///
-    /// If the header is already present, the value will be replaced. If you wish to append a new header,
-    /// use `header_append`.
+    /// The new header is always appended to the request, even if the header already exists.
     ///
     /// # Panics
     /// This method will panic if the value is invalid.


### PR DESCRIPTION
Some parts of the documentation for `header_append` methods was copy/pasted from `header` ones and was therefore incorrect.