### PR TITLE
port to multipart 0.17 and mime 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ serde_json = { version = "1", optional = true }
 serde_urlencoded = { version = "0.6", optional = true }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.19", optional = true }
-multipart = { version = "0.16.1", optional = true }
-mime = { version = "0.2", optional = true }
+multipart = { version = "0.17.0", optional = true }
+mime = { version = "0.3", optional = true }
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "ios")))'.dependencies]
 openssl = { version = "0.10.26", optional = true }

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -33,7 +33,7 @@ impl<'key, 'data> MultipartFile<'key, 'data> {
         let mime_str = mime_type.as_ref();
         let mime: Mime = match mime_str.parse() {
             Ok(mime) => mime,
-            Err(()) => return Err(Error(Box::new(ErrorKind::InvalidMimeType(mime_str.to_string())))),
+            Err(error) => return Err(Error(Box::new(ErrorKind::InvalidMimeType(error.to_string())))),
         };
         Ok(Self {
             mime: Some(mime),

--- a/tests/test_multipart.rs
+++ b/tests/test_multipart.rs
@@ -21,7 +21,7 @@ fn start_server() -> (u16, Receiver<Option<String>>) {
             warp::header::<Mime>("content-type")
                 .and_then(|ct: Mime| async move {
                     ct.get_param("boundary")
-                        .map(ToString::to_string)
+                        .map(|mime| mime.to_string())
                         .ok_or_else(warp::reject::reject)
                 })
                 .and(warp::body::bytes())
@@ -42,12 +42,7 @@ fn start_server() -> (u16, Receiver<Option<String>>) {
                 } else if !found_file
                     && &*entry.headers.name == "file"
                     && entry.headers.filename.as_deref() == Some("hello.txt")
-                    && entry
-                        .headers
-                        .content_type
-                        .as_ref()
-                        .map(|x| x.to_string() == "text/plain")
-                        == Some(true)
+                    && entry.headers.content_type.as_ref().map(|x| x.as_ref() == "text/plain") == Some(true)
                     && buf == "Hello, world!"
                 {
                     found_file = true;


### PR DESCRIPTION
porting to multipart 0.17 required to also bump mime to 0.3 (because multipart 0.17 now uses mime 0.3).
mime had some minor API changes, for which I made adaptations to the multipart module and the multipart tests.

All tests passed locally with `cargo test --all-features`.