### PR TITLE
RFC: Drop invalid headers instead of raising an error

### DIFF
--- a/src/parsing/response.rs
+++ b/src/parsing/response.rs
@@ -55,10 +55,15 @@ where
         let header = trim_byte(b' ', &line[..col]);
         let value = trim_byte(b' ', &line[col + 1..]);
 
-        headers.append(
-            HeaderName::from_bytes(header).map_err(http::Error::from)?,
-            HeaderValue::from_bytes(value).map_err(http::Error::from)?,
-        );
+        let header = match HeaderName::from_bytes(header) {
+            Ok(val) => val,
+            Err(err) => {
+                warn!("Dropped invalid response header: {}", err);
+                continue;
+            }
+        };
+
+        headers.append(header, HeaderValue::from_bytes(value).map_err(http::Error::from)?);
     }
 
     Ok((status, headers))


### PR DESCRIPTION
This follows Firefox and cURL to support broken sites, for example sites that contain PHP errors mixed into the header part of their HTTP response:
```
Server: Apache/2.2.3 (CentOS)
PHP Warning: PHP Startup: Unable to load dynamic library '/usr/local/php5/lib/php//usr/lib/php/modules/mcrypt.so' - /usr/local/php5/lib/php//usr/lib/php/modules/mcrypt.so: cannot open shared object file: No such file or directory in Unknown on line 0, PHP Startup: Unable to load dynamic library '/usr/local/php5/lib/php//usr/local/php5/lib/php/libmcrypt.so' - /usr/local/php5/lib/php//usr/local/php5/lib/php/libmcrypt.so: cannot open shared object file: No such file or directory in Unknown on line 0
X-Powered-By: PHP/5.2.4
```

Fixes #92 