### PR TITLE
RFC: Handle line-folded headers

### DIFF
--- a/src/parsing/buffers.rs
+++ b/src/parsing/buffers.rs
@@ -18,6 +18,29 @@ where
     Ok(n)
 }
 
+pub fn read_line_strict<R>(reader: &mut BufReader<R>, buf: &mut Vec<u8>, max_buf_len: u64) -> io::Result<usize>
+where
+    R: Read,
+{
+    buf.clear();
+    let mut reader = reader.take(max_buf_len);
+    let mut n = 0;
+
+    loop {
+        let k = reader.read_until(b'\n', buf)?;
+        n += k;
+
+        if k == 0 || buf[buf.len() - 1] != b'\n' {
+            return Err(io::ErrorKind::UnexpectedEof.into());
+        }
+
+        if k >= 2 && buf[buf.len() - 2] == b'\r' && buf[buf.len() - 1] == b'\n' {
+            buf.truncate(buf.len() - 2);
+            return Ok(n);
+        }
+    }
+}
+
 pub fn read_line_ending<R>(reader: &mut BufReader<R>) -> io::Result<bool>
 where
     R: Read,
@@ -42,6 +65,14 @@ pub fn trim_byte_left(byte: u8, buf: &[u8]) -> &[u8] {
 
 pub fn trim_byte_right(byte: u8, buf: &[u8]) -> &[u8] {
     buf.iter().rposition(|b| *b != byte).map_or(&[], |n| &buf[..=n])
+}
+
+pub fn replace_byte(byte: u8, replace: u8, buf: &mut [u8]) {
+    for val in buf {
+        if *val == byte {
+            *val = replace;
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -141,6 +172,65 @@ fn test_read_line_beyond_limit() {
         io::ErrorKind::UnexpectedEof
     );
     assert_eq!(line, b"12345");
+}
+
+#[test]
+fn test_read_line_strict() {
+    let mut reader = BufReader::new(&b"foo\r\nbar\r\n"[..]);
+    let mut line = Vec::new();
+
+    assert_eq!(
+        read_line_strict(&mut reader, &mut line, u64::max_value()).ok(),
+        Some(3 + 2)
+    );
+    assert_eq!(line, b"foo");
+}
+
+#[test]
+fn test_read_line_strict_empty_crlf() {
+    let mut reader = BufReader::new(&b"\r\n"[..]);
+    let mut line = Vec::new();
+
+    assert_eq!(read_line_strict(&mut reader, &mut line, u64::max_value()).ok(), Some(2));
+    assert_eq!(line, b"");
+}
+
+#[test]
+fn test_read_line_strict_missing_crlf() {
+    let mut reader = BufReader::new(&b"foo\n"[..]);
+    let mut line = Vec::new();
+
+    assert_eq!(
+        read_line_strict(&mut reader, &mut line, u64::max_value())
+            .unwrap_err()
+            .kind(),
+        io::ErrorKind::UnexpectedEof
+    );
+    assert_eq!(line, b"foo\n");
+}
+
+#[test]
+fn test_read_line_strict_inner_lf() {
+    let mut reader = BufReader::new(&b"123\n456\n789\n0\r\nABC"[..]);
+    let mut line = Vec::new();
+
+    assert_eq!(
+        read_line_strict(&mut reader, &mut line, u64::max_value()).ok(),
+        Some(10 + 3 + 2)
+    );
+    assert_eq!(line, b"123\n456\n789\n0");
+}
+
+#[test]
+fn test_read_line_strict_inner_cr() {
+    let mut reader = BufReader::new(&b"123\r456\r789\r0\r\nXYZ"[..]);
+    let mut line = Vec::new();
+
+    assert_eq!(
+        read_line_strict(&mut reader, &mut line, u64::max_value()).ok(),
+        Some(10 + 3 + 2)
+    );
+    assert_eq!(line, b"123\r456\r789\r0");
 }
 
 #[test]


### PR DESCRIPTION
Split header lines only at CRLF boundary and replacing LF by SP in the resulting values.

Fixes #94 