### PR TITLE
Limit number of stored headers...

### DIFF
--- a/src/parsing/body_reader.rs
+++ b/src/parsing/body_reader.rs
@@ -58,7 +58,7 @@ fn is_chunked(headers: &HeaderMap) -> bool {
 
 fn parse_content_length(val: &HeaderValue) -> Result<u64> {
     let val = val.to_str().map_err(|_| InvalidResponseKind::ContentLength)?;
-    let val: u64 = u64::from_str_radix(val, 10).map_err(|_| InvalidResponseKind::ContentLength)?;
+    let val = val.parse::<u64>().map_err(|_| InvalidResponseKind::ContentLength)?;
     Ok(val)
 }
 

--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -293,6 +293,14 @@ impl<B> RequestBuilder<B> {
         Ok(self)
     }
 
+    /// Set the maximum number of headers accepted in responses to this request.
+    ///
+    /// The default is 100.
+    pub fn max_headers(mut self, max_headers: usize) -> Self {
+        self.base_settings.max_headers = max_headers;
+        self
+    }
+
     /// Set the maximum number of redirections this request can perform.
     ///
     /// The default is 5.

--- a/src/request/session.rs
+++ b/src/request/session.rs
@@ -152,6 +152,13 @@ impl Session {
         Ok(())
     }
 
+    /// Set the maximum number of headers accepted in responses to this request.
+    ///
+    /// The default is 100.
+    pub fn max_headers(&mut self, max_headers: usize) {
+        self.base_settings.max_headers = max_headers;
+    }
+
     /// Set the maximum number of redirections this `Request` can perform.
     ///
     /// The default is 5.

--- a/src/request/settings.rs
+++ b/src/request/settings.rs
@@ -11,6 +11,7 @@ use crate::tls::Certificate;
 #[derive(Clone, Debug)]
 pub struct BaseSettings {
     pub headers: HeaderMap,
+    pub max_headers: usize,
     pub max_redirections: u32,
     pub follow_redirects: bool,
     pub connect_timeout: Duration,
@@ -31,6 +32,7 @@ impl Default for BaseSettings {
     fn default() -> Self {
         BaseSettings {
             headers: HeaderMap::new(),
+            max_headers: 100,
             max_redirections: 5,
             follow_redirects: true,
             connect_timeout: Duration::from_secs(30),

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -86,7 +86,7 @@ impl BaseStream {
         write!(stream, "\r\n")?;
 
         let mut stream = BufReaderWrite::new(stream);
-        let (status, _) = parse_response_head(&mut stream)?;
+        let (status, _) = parse_response_head(&mut stream, base_settings.max_headers)?;
 
         if !status.is_success() {
             // Error initializaing tunnel, get status code and up to 10 KiB of data from the body.


### PR DESCRIPTION
…to avoid local resource exhaustion by malicious server.

Fixes #101
Fixes #102

@sbstp @Shnatsel Two design issue I see here
* Do we silently drop the headers but continue to parse them (with e.g. a request timeout kicking in eventually) or raise an error and fail the request? (Another option might be to log once that we started dropping them.)
* Do we keep this a hard-coded constant (similar to what we do for `MAX_LINE_LENGTH`) or make it an option user code can modify via the API?