### PR TITLE
fix(multipart): disable default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ flate2 = {version = "1.0", optional = true}
 http = "0.2"
 log = "0.4"
 mime = {version = "0.3", optional = true}
-multipart = {version = "0.18", optional = true}
+multipart = {version = "0.18", default-features = false, features = ["client"], optional = true}
 native-tls = {version = "0.2", optional = true}
 rustls-opt-dep = {package = "rustls", version = "0.20", features = ["dangerous_configuration"], optional = true}
 serde = {version = "1", optional = true}


### PR DESCRIPTION
The `multipart` crate is outdated and has several security vulnerabilites (you can check them running `cargo install cargo-audit && cargo audit`). This PR disables its default features so it doesn't pull outdated crates that uses vulnerable versions of chrono, time and hyper.