### PR TITLE
feat: allow changing the `Connection` header

### DIFF
--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -422,7 +422,7 @@ impl<B: Body> RequestBuilder<B> {
             base_settings: self.base_settings,
         };
 
-        header_insert(&mut prepped.base_settings.headers, CONNECTION, "close")?;
+        header_insert_if_missing(&mut prepped.base_settings.headers, CONNECTION, "close")?;
         prepped.set_compression()?;
         match prepped.body.kind()? {
             BodyKind::Empty => (),


### PR DESCRIPTION
The `Connection` header is always set to `close` even if we set it manually in the request builder. If the proposed solution is not desired, we could also expose a header method in the PreparedRequest struct.

Related to https://github.com/tauri-apps/tauri/issues/3889