### PR TITLE
fix(multipart): always stream body

### DIFF
--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -96,10 +96,7 @@ pub struct Multipart<'data> {
 
 impl Body for Multipart<'_> {
     fn kind(&mut self) -> IoResult<BodyKind> {
-        match self.data.content_len() {
-            Some(len) => Ok(BodyKind::KnownLength(len)),
-            None => Ok(BodyKind::Chunked),
-        }
+        Ok(BodyKind::Chunked)
     }
 
     fn write<W: Write>(&mut self, mut writer: W) -> IoResult<()> {


### PR DESCRIPTION
The multipart crate used by attohttpc has an issue when the form has only text fields, they are not computing the content length properly. I believe the problem is [here](https://github.com/abonander/multipart/blob/f4fee608af93bcad363b080849e4c3c56b622217/src/client/lazy.rs#L282) where the `text_data` is appended with the proper value but the `content_len` is not changed (so you only get the right body posted when `use_len === false`. I could open a PR to their repo but I'm afraid it won't be merged since the project seems unmaintained, so I open this change here hoping it won't cause any issues.