### PR TITLE
Add optional base64 dependency to make RequestBuilder::basic_auth generally available.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 repository = "https://github.com/sbstp/attohttpc"
 
 [dependencies]
+base64 = {version = "0.13", optional=true}
 encoding_rs = {version = "0.8", optional = true}
 encoding_rs_io = {version = "0.1", optional = true}
 flate2 = {version = "1.0", optional = true}

--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -125,12 +125,7 @@ impl<B> RequestBuilder<B> {
     }
 
     /// Enable HTTP basic authentication.
-    ///
-    /// This is available only on Linux and when TLS support is enabled.
-    #[cfg(all(
-        feature = "tls",
-        not(any(target_os = "windows", target_os = "macos", target_os = "ios"))
-    ))]
+    #[cfg(feature = "base64")]
     pub fn basic_auth(self, username: impl std::fmt::Display, password: Option<impl std::fmt::Display>) -> Self {
         let auth = match password {
             Some(password) => format!("{}:{}", username, password),
@@ -138,7 +133,7 @@ impl<B> RequestBuilder<B> {
         };
         self.header(
             http::header::AUTHORIZATION,
-            format!("Basic {}", openssl::base64::encode_block(auth.as_bytes())),
+            format!("Basic {}", base64::encode(auth.as_bytes())),
         )
     }
 


### PR DESCRIPTION
Tested this manually using the `cat` example against [httpbin.org](https://httpbin.org/#/Auth/get_basic_auth__user___passwd_) to ensure that the default base64 variant is the correct one. I also removed the part of the doc comment mentioning the required feature as docs.rs displays this itself nowadays.

Closes #123 