### PR TITLE
Match curl's behavior for root domains in 'no_proxy'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ target/
 **/*.rs.bk
 Cargo.lock
 .vscode
+.idea
+*.iml


### PR DESCRIPTION
I have an additional update to Issue #120 

In curl, the 'no_proxy' env var can include root domains, that will match all sub-domains.  I think its semantics are complicated, and not well documented, but here's pretty nice breakdown for it:

https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/

TLDR - curl allows you to declare a root domain in the 'no_proxy' var, and it will apply to any sub-domain of that root as well. It will also drop any preceding dot given in the root domain, so that to bare root also matches.

Ex: 
```
$ export no_proxy=.myroot.com     # converted to myroot.com
$ curl https://mysub.myroot.com    # will bypass any proxy setting
```