### PR TITLE
Allow to use flate2 with zlib or zlib-ng instead of miniz_oxide

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/sbstp/attohttpc"
 base64 = {version = "0.13.0", optional = true}
 encoding_rs = {version = "0.8.31", optional = true}
 encoding_rs_io = {version = "0.1.7", optional = true}
-flate2 = {version = "1.0.24", optional = true}
+flate2 = {version = "1.0.24", default-features = false, optional = true}
 http = "0.2.8"
 log = "0.4.17"
 mime = {version = "0.3.16", optional = true}
@@ -46,7 +46,10 @@ warp = "0.3.2"
 [features]
 basic-auth = ["base64"]
 charsets = ["encoding_rs", "encoding_rs_io"]
-compress = ["flate2"]
+# The following three compress features are mutually exclusive.
+compress = ["flate2/default"]
+compress-zlib = ["flate2/zlib"]
+compress-zlib-ng = ["flate2/zlib-ng"]
 default = ["compress", "tls"]
 form = ["serde", "serde_urlencoded"]
 json = ["serde", "serde_json"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ possible to allow users to get just what they need. Here are the goals of the pr
 ## Features
 * `basic-auth` support for basic auth
 * `charsets` support for decoding more text encodings than just UTF-8
-* `compress` support for decompressing response bodies (**default**)
+* `compress` support for decompressing response bodies using `miniz_oxide` (**default**)
+* `compress-zlib` support for decompressing response bodies using `zlib` instead of `miniz_oxide` (see [flate2 backends](https://github.com/rust-lang/flate2-rs#backends))
+* `compress-zlib-ng` support for decompressing response bodies using `zlib-ng` instead of `miniz_oxide` (see [flate2 backends](https://github.com/rust-lang/flate2-rs#backends))
 * `json` support for serialization and deserialization
 * `form` support for url encoded forms (does not include support for multipart)
 * `multipart-form` support for multipart forms (does not include support for url encoding)

--- a/run-tests.bash
+++ b/run-tests.bash
@@ -16,6 +16,8 @@ cargo test --no-default-features
 cargo test --no-default-features --features basic-auth
 cargo test --no-default-features --features charsets
 cargo test --no-default-features --features compress
+cargo test --no-default-features --features compress-zlib
+cargo test --no-default-features --features compress-zlib-ng
 cargo test --no-default-features --features form
 cargo test --no-default-features --features multipart-form
 cargo test --no-default-features --features json

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,11 @@
 //! # Features
 //! * `basic-auth` support for basic auth
 //! * `charsets` support for decoding more text encodings than just UTF-8
-//! * `compress` support for decompressing response bodies (**default**)
+//! * `compress` support for decompressing response bodies using `miniz_oxide` (**default**)
+//! * `compress-zlib` support for decompressing response bodies using `zlib` instead of `miniz_oxide`
+//!   (see [flate2 backends](https://github.com/rust-lang/flate2-rs#backends))
+//! * `compress-zlib-ng` support for decompressing response bodies using `zlib-ng` instead of `miniz_oxide`
+//!   (see [flate2 backends](https://github.com/rust-lang/flate2-rs#backends))
 //! * `json` support for serialization and deserialization
 //! * `form` support for url encoded forms (does not include support for multipart)
 //! * `multipart-form` support for multipart forms (does not include support for url encoding)


### PR DESCRIPTION
This allows building flate2 against system-provided (or with vendored) zlib or zlib-ng library.