### PR TITLE
Add feature to support rustls-native-certs root certificates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ log = "0.4.17"
 mime = {version = "0.3.16", optional = true}
 multipart = {version = "0.18.0", default-features = false, features = ["client"], optional = true}
 native-tls = {version = "0.2.10", optional = true}
+rustls-native-certs = { version = "0.6", optional = true}
 rustls-opt-dep = {package = "rustls", version = "0.20.6", features = ["dangerous_configuration"], optional = true}
 serde = {version = "1.0.143", optional = true}
 serde_json = {version = "1.0.83", optional = true}
@@ -58,6 +59,7 @@ rustls = ["tls-rustls"]
 tls = ["native-tls"]
 tls-vendored = ["native-tls/vendored"]
 tls-rustls = ["rustls-opt-dep", "webpki", "webpki-roots"]
+tls-rustls-native-roots = ["tls-rustls", "rustls-native-certs"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ possible to allow users to get just what they need. Here are the goals of the pr
 * `tls` support for tls connections (**default**)
 * `tls-vendored` activate the `vendored` feature of `native-tls` crate
 * `rustls` or `tls-rustls` support for TLS connections using `rustls` instead of `native-tls`
+* `tls-rustls-native-roots` support for TLS connections using `rustls` with additional root certificates from the `rustls-native-certs` crate
 
 ## Usage
 See the `examples/` folder in the repository for more use cases.

--- a/run-tests.bash
+++ b/run-tests.bash
@@ -23,3 +23,4 @@ cargo test --no-default-features --features multipart-form
 cargo test --no-default-features --features json
 cargo test --no-default-features --features tls
 cargo test --no-default-features --features tls-rustls
+cargo test --no-default-features --features tls-rustls-native-roots

--- a/src/request/proxy.rs
+++ b/src/request/proxy.rs
@@ -79,7 +79,7 @@ impl ProxySettings {
         if !disable_proxies {
             if let Some(no_proxy) = no_proxy {
                 no_proxy_hosts.extend(no_proxy.split(',').map(|s|
-                    s.trim().trim_start_matches(".").to_lowercase()));
+                    s.trim().trim_start_matches('.').to_lowercase()));
             }
         }
 


### PR DESCRIPTION
Closes #133 

Info
-----
* As mentioned in the issue, adding a feature flag to enable `rustls-native-certs` as root certificates allows consumers to easily opt-in to the native certificate stores.
* Inspired by how the similar feature works in Reqwest, the feature flag for this is all-inclusive, automatically activating `tls-rustls` as well.

Changes
-----
* Added a feature flag `tls-rustls-native-roots` to enable loading the native certificates as root certificates for requests.
* If the feature flag is enabled, load all of the native certs as root certificates.
    * We also ignore errors, as the native certs are sometimes invalid and we don't want to interrupt the entire request process if the user has an invalid cert somewhere in their native store.

Notes
-----
* I left the webpki certificate loading in regardless of the feature flag, as that's the current behavior and it seemed most reasonable to have the feature flag be additive, rather than a toggle.
* I'm not sure if we want to have a "valid" counter the way that Reqwest does, so that we can error out if the native cert check failed to load any valid certs? If that's a useful feature I'm happy to add, but I left it out in the interest of simplicity.
* I also updated a `"."` to `'.'` to resolve a clippy warning about using a single-character string as a pattern.