### PR TITLE
Refactor TLS feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,15 +51,23 @@ charsets = ["encoding_rs", "encoding_rs_io"]
 compress = ["flate2/default"]
 compress-zlib = ["flate2/zlib"]
 compress-zlib-ng = ["flate2/zlib-ng"]
-default = ["compress", "tls"]
+default = ["compress", "tls-native"]
 form = ["serde", "serde_urlencoded"]
 json = ["serde", "serde_json"]
 multipart-form = ["multipart", "mime"]
-rustls = ["tls-rustls"]
-tls = ["native-tls"]
-tls-vendored = ["native-tls/vendored"]
-tls-rustls = ["rustls-opt-dep", "webpki", "webpki-roots"]
-tls-rustls-native-roots = ["tls-rustls", "rustls-native-certs"]
+# The following TLS features are mutually exclusive
+tls-native = ["native-tls"]
+tls-rustls-webpki-roots = ["__rustls", "webpki-roots"]
+tls-rustls-native-roots = ["__rustls", "rustls-native-certs"]
+# This feature depends on tls-native
+tls-native-vendored = ["native-tls/vendored"]
+# These features are provided for backwards compatibility
+tls = ["tls-native"]
+rustls = ["tls-rustls-webpki-roots"]
+tls-rustls = ["tls-rustls-webpki-roots"]
+tls-vendored = ["tls-native-vendored"]
+# Internal feature used to indicate rustls support
+__rustls = ["rustls-opt-dep", "webpki"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -72,12 +80,12 @@ required-features = ["default"]
 [[example]]
 name = "imdb"
 path = "examples/imdb.rs"
-required-features = ["tls"]
+required-features = ["tls-native"]
 
 [[example]]
 name = "nhlapi"
 path = "examples/nhlapi.rs"
-required-features = ["tls"]
+required-features = ["tls-native"]
 
 [[example]]
 name = "post_json"
@@ -87,7 +95,7 @@ required-features = ["json"]
 [[example]]
 name = "post"
 path = "examples/post.rs"
-required-features = ["tls"]
+required-features = ["tls-native"]
 
 [[example]]
 name = "charset"
@@ -102,7 +110,7 @@ required-features = ["multipart-form"]
 [[test]]
 name = "test_invalid_certs"
 path = "tests/test_invalid_certs.rs"
-required-features = ["tls"]
+required-features = ["tls-native"]
 
 [[test]]
 name = "test_multipart"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ possible to allow users to get just what they need. Here are the goals of the pr
 * `json` support for serialization and deserialization
 * `form` support for url encoded forms (does not include support for multipart)
 * `multipart-form` support for multipart forms (does not include support for url encoding)
-* `tls` support for tls connections (**default**)
-* `tls-vendored` activate the `vendored` feature of `native-tls` crate
-* `rustls` or `tls-rustls` support for TLS connections using `rustls` instead of `native-tls`
+* `tls-native` support for tls connections using the `native-tls` crate (**default**)
+* `tls-native-vendored` activate the `vendored` feature of `native-tls`
+* `tls-rustls-webpki-roots` support for TLS connections using `rustls` instead of `native-tls` with Web PKI roots
 * `tls-rustls-native-roots` support for TLS connections using `rustls` with root certificates loaded from the `rustls-native-certs` crate
 
 ## Usage

--- a/run-tests.bash
+++ b/run-tests.bash
@@ -22,5 +22,6 @@ cargo test --no-default-features --features form
 cargo test --no-default-features --features multipart-form
 cargo test --no-default-features --features json
 cargo test --no-default-features --features tls-native
+cargo test --no-default-features --features tls-native,tls-native-vendored
 cargo test --no-default-features --features tls-rustls-webpki-roots
 cargo test --no-default-features --features tls-rustls-native-roots

--- a/run-tests.bash
+++ b/run-tests.bash
@@ -21,6 +21,6 @@ cargo test --no-default-features --features compress-zlib-ng
 cargo test --no-default-features --features form
 cargo test --no-default-features --features multipart-form
 cargo test --no-default-features --features json
-cargo test --no-default-features --features tls
-cargo test --no-default-features --features tls-rustls
+cargo test --no-default-features --features tls-native
+cargo test --no-default-features --features tls-rustls-webpki-roots
 cargo test --no-default-features --features tls-rustls-native-roots

--- a/src/error.rs
+++ b/src/error.rs
@@ -77,20 +77,20 @@ pub enum ErrorKind {
     #[cfg(feature = "form")]
     UrlEncoded(serde_urlencoded::ser::Error),
     /// TLS error encountered while connecting to an https server.
-    #[cfg(feature = "tls")]
+    #[cfg(feature = "tls-native")]
     Tls(native_tls::Error),
     /// TLS error encountered while connecting to an https server.
-    #[cfg(all(feature = "tls-rustls", not(feature = "tls")))]
+    #[cfg(all(feature = "__rustls", not(feature = "tls-native")))]
     Tls(rustls::Error),
     /// Invalid DNS name used for TLS certificate verification
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "__rustls")]
     InvalidDNSName(String),
     /// Invalid mime type in a Multipart form
     InvalidMimeType(String),
     /// TLS was not enabled by features.
     TlsDisabled,
     /// WebPKI error.
-    #[cfg(feature = "tls-rustls")]
+    #[cfg(feature = "__rustls")]
     WebPKI(webpki::Error),
 }
 
@@ -129,13 +129,13 @@ impl Display for Error {
             Json(ref e) => write!(w, "Json Error: {}", e),
             #[cfg(feature = "form")]
             UrlEncoded(ref e) => write!(w, "URL Encoding Error: {}", e),
-            #[cfg(any(feature = "tls", feature = "tls-rustls"))]
+            #[cfg(any(feature = "tls-native", feature = "__rustls"))]
             Tls(ref e) => write!(w, "Tls Error: {}", e),
-            #[cfg(feature = "tls-rustls")]
+            #[cfg(feature = "__rustls")]
             InvalidDNSName(ref e) => write!(w, "Invalid DNS name: {}", e),
             InvalidMimeType(ref e) => write!(w, "Invalid mime type: {}", e),
-            TlsDisabled => write!(w, "TLS is disabled, activate tls or tls-rustls feature"),
-            #[cfg(feature = "tls-rustls")]
+            TlsDisabled => write!(w, "TLS is disabled, activate one of the tls- features"),
+            #[cfg(feature = "__rustls")]
             WebPKI(ref e) => write!(w, "WebPKI error: {}", e),
         }
     }
@@ -150,9 +150,9 @@ impl StdError for Error {
             Http(ref e) => Some(e),
             #[cfg(feature = "json")]
             Json(ref e) => Some(e),
-            #[cfg(any(feature = "tls", feature = "tls-rustls"))]
+            #[cfg(any(feature = "tls-native", feature = "__rustls"))]
             Tls(ref e) => Some(e),
-            #[cfg(feature = "tls-rustls")]
+            #[cfg(feature = "__rustls")]
             WebPKI(ref e) => Some(e),
             _ => None,
         }
@@ -183,14 +183,14 @@ impl From<http::header::InvalidHeaderValue> for Error {
     }
 }
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "tls-native")]
 impl From<native_tls::Error> for Error {
     fn from(err: native_tls::Error) -> Error {
         Error(Box::new(ErrorKind::Tls(err)))
     }
 }
 
-#[cfg(all(feature = "tls-rustls", not(feature = "tls")))]
+#[cfg(all(feature = "__rustls", not(feature = "tls-native")))]
 impl From<rustls::Error> for Error {
     fn from(err: rustls::Error) -> Error {
         Error(Box::new(ErrorKind::Tls(err)))
@@ -235,7 +235,7 @@ impl From<InvalidResponseKind> for io::Error {
     }
 }
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "__rustls")]
 impl From<webpki::Error> for Error {
     fn from(err: webpki::Error) -> Error {
         Error(Box::new(ErrorKind::WebPKI(err)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,9 +48,10 @@
 //! * `json` support for serialization and deserialization
 //! * `form` support for url encoded forms (does not include support for multipart)
 //! * `multipart-form` support for multipart forms (does not include support for url encoding)
-//! * `tls` support for tls connections (**default**)
-//! * `tls-vendored` activate the `vendored` feature of `native-tls` crate
-//! * `rustls` or `tls-rustls` support for TLS connections using `rustls` instead of `native-tls`
+//! * `tls-native` support for tls connections using the `native-tls` crate (**default**)
+//! * `tls-native-vendored` activate the `vendored` feature of `native-tls`
+//! * `tls-rustls-webpki-roots` support for TLS connections using `rustls` instead of `native-tls` with Web PKI roots
+//! * `tls-rustls-native-roots` support for TLS connections using `rustls` with root certificates loaded from the `rustls-native-certs` crate
 //!
 //! # Activating a feature
 //! To activate a feature, specify it in your `Cargo.toml` file like so
@@ -59,7 +60,7 @@
 //! ```
 //!
 
-#[cfg(feature = "tls-rustls")]
+#[cfg(feature = "__rustls")]
 extern crate rustls_opt_dep as rustls;
 
 macro_rules! debug {

--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -479,7 +479,7 @@ impl<B> RequestInspector<'_, B> {
 }
 
 #[test]
-#[cfg(feature = "tls")]
+#[cfg(feature = "tls-native")]
 fn test_accept_invalid_certs_disabled_by_default() {
     let builder = RequestBuilder::new(Method::GET, "https://localhost:7900");
     assert!(!builder.base_settings.accept_invalid_certs);

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -1,17 +1,17 @@
-#[cfg(feature = "tls")]
+#[cfg(feature = "tls-native")]
 mod native_tls_impl;
 
-#[cfg(all(feature = "tls-rustls", not(feature = "tls")))]
+#[cfg(all(feature = "__rustls", not(feature = "tls-native")))]
 mod rustls_impl;
 
-#[cfg(all(not(feature = "tls"), not(feature = "tls-rustls")))]
+#[cfg(all(not(feature = "tls-native"), not(feature = "__rustls")))]
 mod no_tls_impl;
 
-#[cfg(feature = "tls")]
+#[cfg(feature = "tls-native")]
 pub use native_tls_impl::*;
 
-#[cfg(all(feature = "tls-rustls", not(feature = "tls")))]
+#[cfg(all(feature = "__rustls", not(feature = "tls-native")))]
 pub use rustls_impl::*;
 
-#[cfg(all(not(feature = "tls"), not(feature = "tls-rustls")))]
+#[cfg(all(not(feature = "tls-native"), not(feature = "__rustls")))]
 pub use no_tls_impl::*;

--- a/src/tls/rustls_impl.rs
+++ b/src/tls/rustls_impl.rs
@@ -5,7 +5,7 @@ use std::io::prelude::*;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-#[cfg(not(feature = "tls-rustls-native-roots"))]
+#[cfg(feature = "tls-rustls-webpki-roots")]
 use rustls::OwnedTrustAnchor;
 use rustls::{
     client::{ServerCertVerified, ServerCertVerifier, WebPkiVerifier},
@@ -13,7 +13,7 @@ use rustls::{
 };
 #[cfg(feature = "tls-rustls-native-roots")]
 use rustls_native_certs::load_native_certs;
-#[cfg(not(feature = "tls-rustls-native-roots"))]
+#[cfg(feature = "tls-rustls-webpki-roots")]
 use webpki_roots::TLS_SERVER_ROOTS;
 
 use crate::{Error, ErrorKind, Result};
@@ -58,7 +58,7 @@ impl TlsHandshaker {
             None => {
                 let mut root_store = RootCertStore::empty();
 
-                #[cfg(not(feature = "tls-rustls-native-roots"))]
+                #[cfg(feature = "tls-rustls-webpki-roots")]
                 root_store.add_server_trust_anchors(TLS_SERVER_ROOTS.0.iter().map(|root| {
                     OwnedTrustAnchor::from_subject_spki_name_constraints(root.subject, root.spki, root.name_constraints)
                 }));

--- a/tests/test_proxy.rs
+++ b/tests/test_proxy.rs
@@ -25,7 +25,7 @@ async fn test_http_url_with_http_proxy() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[cfg(any(feature = "tls", feature = "tls-rustls"))]
+#[cfg(any(feature = "tls-native", feature = "__rustls"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_http_url_with_https_proxy() -> Result<(), anyhow::Error> {
     let remote_port = tools::start_hello_world_server(false).await?;
@@ -49,7 +49,7 @@ async fn test_http_url_with_https_proxy() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[cfg(any(feature = "tls", feature = "tls-rustls"))]
+#[cfg(any(feature = "tls-native", feature = "__rustls"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_https_url_with_http_proxy() -> Result<(), anyhow::Error> {
     let remote_port = tools::start_hello_world_server(true).await?;
@@ -73,7 +73,7 @@ async fn test_https_url_with_http_proxy() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[cfg(any(feature = "tls", feature = "tls-rustls"))]
+#[cfg(any(feature = "tls-native", feature = "__rustls"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_https_url_with_https_proxy() -> Result<(), anyhow::Error> {
     let remote_port = tools::start_hello_world_server(true).await?;
@@ -150,7 +150,7 @@ async fn test_https_url_with_http_proxy_refusal() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[cfg(any(feature = "tls", feature = "tls-rustls"))]
+#[cfg(any(feature = "tls-native", feature = "__rustls"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_http_url_with_https_proxy_refusal() -> Result<(), anyhow::Error> {
     let proxy_port = tools::start_refusing_proxy_server(true).await?;
@@ -176,7 +176,7 @@ async fn test_http_url_with_https_proxy_refusal() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-#[cfg(any(feature = "tls", feature = "tls-rustls"))]
+#[cfg(any(feature = "tls-native", feature = "__rustls"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_https_url_with_https_proxy_refusal() -> Result<(), anyhow::Error> {
     let proxy_port = tools::start_refusing_proxy_server(true).await?;


### PR DESCRIPTION
Info
-----
* Suggested in https://github.com/sbstp/attohttpc/pull/134#discussion_r1012520798, a cleanup of the various TLS feature flags so they are consistently named
* For compatibility, I kept the old names around as aliases, but removed the references to them in README and the root doc comments.

Changes
-----
* Updated the names of the core TLS features to be more consistent
* Added aliases to those with the existing feature names
* Added an internal feature `__rustls` to indicate Rustls support is enabled (with either kind of root certificates)
* Updated references in the code to the TLS features to use the new names

Notes
-----
* This PR builds on the changes in #134, so I'll leave it as a draft for now. To see only the new changes, check out only the [last commit](https://github.com/sbstp/attohttpc/pull/135/commits/0331de2b0927342d23d254bf4c50fc6a04f42d5d)