### PR TITLE
Add a method to set the URL's query from an object

### DIFF
--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -124,6 +124,13 @@ impl<B> RequestBuilder<B> {
         self
     }
 
+    /// Set the query parameters of this request to be the URL-encoded representation of the given object.
+    #[cfg(feature = "form")]
+    pub fn query<T: serde::Serialize>(mut self, value: &T) -> Result<Self> {
+        value.serialize(serde_urlencoded::Serializer::new(&mut self.url.query_pairs_mut()))?;
+        Ok(self)
+    }
+
     /// Enable HTTP basic authentication.
     #[cfg(feature = "basic-auth")]
     pub fn basic_auth(self, username: impl std::fmt::Display, password: Option<impl std::fmt::Display>) -> Self {


### PR DESCRIPTION
Example:
```rust
let query = json!({"page": 8, "order": "asc", "details": false});
attohttpc::get("http://foo.bar").query(&query)?;
```

This is equivalent to *reqwest*'s [query method](https://docs.rs/reqwest/latest/reqwest/blocking/struct.RequestBuilder.html#method.query).

(Unfortunately, we can't use `.params(query.as_object()?)` here, because the `ToString` implementation for the string value retains the quote characters.)