### PR TITLE
Use rustls-pki-types via rustls crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ mime = {version = "0.3.16", optional = true}
 multipart = {version = "0.18.0", default-features = false, features = ["client"], optional = true}
 native-tls = {version = "0.2.10", optional = true}
 rustls-native-certs = { version = "0.7", optional = true}
-rustls-opt-dep = {package = "rustls", version = "0.22.0", optional = true}
-rustls-pki-types = {version = "1", optional = true}
+rustls-opt-dep = {package = "rustls", version = "0.22.1", optional = true}
 serde = {version = "1.0.143", optional = true}
 serde_json = {version = "1.0.83", optional = true}
 serde_urlencoded = {version = "0.7.1", optional = true}
@@ -70,7 +69,7 @@ rustls = ["tls-rustls-webpki-roots"]
 tls-rustls = ["tls-rustls-webpki-roots"]
 tls-vendored = ["tls-native-vendored"]
 # Internal feature used to indicate rustls support
-__rustls = ["rustls-opt-dep", "rustls-pki-types"]
+__rustls = ["rustls-opt-dep"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ multipart = {version = "0.18.0", default-features = false, features = ["client"]
 native-tls = {version = "0.2.10", optional = true}
 rustls-native-certs = { version = "0.7", optional = true}
 rustls-opt-dep = {package = "rustls", version = "0.22.0", optional = true}
-rustls-pki-types = "1"
+rustls-pki-types = {version = "1", optional = true}
 serde = {version = "1.0.143", optional = true}
 serde_json = {version = "1.0.83", optional = true}
 serde_urlencoded = {version = "0.7.1", optional = true}
@@ -70,7 +70,7 @@ rustls = ["tls-rustls-webpki-roots"]
 tls-rustls = ["tls-rustls-webpki-roots"]
 tls-vendored = ["tls-native-vendored"]
 # Internal feature used to indicate rustls support
-__rustls = ["rustls-opt-dep"]
+__rustls = ["rustls-opt-dep", "rustls-pki-types"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/tls/rustls_impl.rs
+++ b/src/tls/rustls_impl.rs
@@ -9,11 +9,11 @@ use rustls::{
         danger::{DangerousClientConfigBuilder, HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
         WebPkiServerVerifier,
     },
+    pki_types::{CertificateDer, ServerName, UnixTime},
     ClientConfig, ClientConnection, DigitallySignedStruct, RootCertStore, SignatureScheme, StreamOwned,
 };
 #[cfg(feature = "tls-rustls-native-roots")]
 use rustls_native_certs::load_native_certs;
-use rustls_pki_types::{CertificateDer, ServerName, UnixTime};
 #[cfg(feature = "tls-rustls-webpki-roots")]
 use webpki_roots::TLS_SERVER_ROOTS;
 


### PR DESCRIPTION
`rustls-pki-types` is only used in `__rustls` feature.