### PR TITLE
Replace lazy_static crate with std::sync::OnceLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ env_logger = "0.10.0"
 futures-util = {version = "0.3.23", default-features = false}
 http02 = {package = "http", version = "0.2"}
 hyper = "0.14.20"
-lazy_static = "1.4.0"
 multipart = {version = "0.18.0", default-features = false, features = ["server"]}
 rustls-pemfile = "2"
 tokio = {version = "1.20.1", features = ["full"]}

--- a/src/request/proxy.rs
+++ b/src/request/proxy.rs
@@ -218,13 +218,10 @@ fn with_reset_proxy_vars<T>(test: T)
 where
     T: FnOnce() + std::panic::UnwindSafe,
 {
-    use std::sync::Mutex;
+    use std::sync::{Mutex, OnceLock};
 
-    lazy_static::lazy_static! {
-        static ref LOCK: Mutex<()> = Mutex::new(());
-    };
-
-    let _guard = LOCK.lock().unwrap();
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let _guard = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
 
     env::remove_var("ALL_PROXY");
     env::remove_var("HTTP_PROXY");


### PR DESCRIPTION
`std::sync::OnceLock` can be used instead of `lazy_static` crate.