### PR TITLE
Refactor response type

### DIFF
--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use attohttpc::Result;
+use attohttpc::{ResponseExt, Result};
 
 fn main() -> Result {
     env_logger::init();

--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use attohttpc::{ResponseExt, Result};
+use attohttpc::Result;
 
 fn main() -> Result {
     env_logger::init();
@@ -10,7 +10,7 @@ fn main() -> Result {
     let resp = attohttpc::get(url).send()?;
     println!("Status: {:?}", resp.status());
     println!("Headers:\n{:#?}", resp.headers());
-    println!("Body:\n{}", resp.text()?);
+    println!("Body:\n{}", resp.into_body().text()?);
 
     Ok(())
 }

--- a/examples/charset.rs
+++ b/examples/charset.rs
@@ -1,9 +1,7 @@
-use attohttpc::ResponseExt;
-
 fn main() -> Result<(), attohttpc::Error> {
     env_logger::init();
 
     let resp = attohttpc::get("https://rust-lang.org/").send()?;
-    println!("{}", resp.text()?);
+    println!("{}", resp.into_body().text()?);
     Ok(())
 }

--- a/examples/charset.rs
+++ b/examples/charset.rs
@@ -1,3 +1,5 @@
+use attohttpc::ResponseExt;
+
 fn main() -> Result<(), attohttpc::Error> {
     env_logger::init();
 

--- a/examples/imdb.rs
+++ b/examples/imdb.rs
@@ -1,5 +1,7 @@
 use std::fs::File;
 
+use attohttpc::ResponseExt;
+
 fn main() -> attohttpc::Result {
     env_logger::init();
 

--- a/examples/imdb.rs
+++ b/examples/imdb.rs
@@ -10,7 +10,7 @@ fn main() -> attohttpc::Result {
     println!("Headers:\n{:#?}", resp.headers());
     if resp.is_success() {
         let file = File::create("title.basics.tsv.gz")?;
-        let n = resp.write_to(file)?;
+        let n = resp.into_body().write_to(file)?;
         println!("Wrote {n} bytes to the file.");
     }
 

--- a/examples/multipart.rs
+++ b/examples/multipart.rs
@@ -1,3 +1,5 @@
+use attohttpc::ResponseExt;
+
 fn main() -> attohttpc::Result {
     env_logger::init();
 

--- a/examples/multipart.rs
+++ b/examples/multipart.rs
@@ -1,5 +1,3 @@
-use attohttpc::ResponseExt;
-
 fn main() -> attohttpc::Result {
     env_logger::init();
 
@@ -15,7 +13,7 @@ fn main() -> attohttpc::Result {
 
     println!("Status: {:?}", resp.status());
     println!("Headers:\n{:#?}", resp.headers());
-    println!("Body:\n{}", resp.text()?);
+    println!("Body:\n{}", resp.into_body().text()?);
 
     Ok(())
 }

--- a/examples/nhlapi.rs
+++ b/examples/nhlapi.rs
@@ -1,3 +1,5 @@
+use attohttpc::ResponseExt;
+
 fn main() -> attohttpc::Result {
     env_logger::init();
 

--- a/examples/nhlapi.rs
+++ b/examples/nhlapi.rs
@@ -1,12 +1,10 @@
-use attohttpc::ResponseExt;
-
 fn main() -> attohttpc::Result {
     env_logger::init();
 
     let resp = attohttpc::get("https://statsapi.web.nhl.com/api/v1/schedule").send()?;
     println!("Status: {:?}", resp.status());
     println!("Headers:\n{:#?}", resp.headers());
-    println!("Body:\n{}", resp.text()?);
+    println!("Body:\n{}", resp.into_body().text()?);
 
     Ok(())
 }

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -1,3 +1,5 @@
+use attohttpc::ResponseExt;
+
 fn main() -> attohttpc::Result {
     env_logger::init();
 

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -1,5 +1,3 @@
-use attohttpc::ResponseExt;
-
 fn main() -> attohttpc::Result {
     env_logger::init();
 
@@ -9,7 +7,7 @@ fn main() -> attohttpc::Result {
 
     println!("Status: {:?}", resp.status());
     println!("Headers:\n{:#?}", resp.headers());
-    println!("Body:\n{}", resp.text()?);
+    println!("Body:\n{}", resp.into_body().text()?);
 
     Ok(())
 }

--- a/examples/post_json.rs
+++ b/examples/post_json.rs
@@ -1,5 +1,7 @@
 use serde_json::json;
 
+use attohttpc::ResponseExt;
+
 fn main() -> attohttpc::Result {
     env_logger::init();
 

--- a/examples/post_json.rs
+++ b/examples/post_json.rs
@@ -1,7 +1,5 @@
 use serde_json::json;
 
-use attohttpc::ResponseExt;
-
 fn main() -> attohttpc::Result {
     env_logger::init();
 
@@ -12,7 +10,7 @@ fn main() -> attohttpc::Result {
     let resp = attohttpc::post("http://httpbin.org/post").json(&body)?.send()?;
     println!("Status: {:?}", resp.status());
     println!("Headers:\n{:#?}", resp.headers());
-    println!("Body:\n{}", resp.text_utf8()?);
+    println!("Body:\n{}", resp.into_body().text_utf8()?);
 
     Ok(())
 }

--- a/examples/session.rs
+++ b/examples/session.rs
@@ -1,11 +1,11 @@
-use attohttpc::{ResponseExt, Result, Session};
+use attohttpc::{Result, Session};
 
 fn main() -> Result {
     let mut sess = Session::new();
     sess.header("Authorization", "Bearer please let me in!");
 
     let resp = sess.get("https://httpbin.org/get").send()?;
-    println!("{}", resp.text()?);
+    println!("{}", resp.into_body().text()?);
 
     Ok(())
 }

--- a/examples/session.rs
+++ b/examples/session.rs
@@ -1,4 +1,4 @@
-use attohttpc::{Result, Session};
+use attohttpc::{ResponseExt, Result, Session};
 
 fn main() -> Result {
     let mut sess = Session::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 //! # #[cfg(feature = "json")]
 //! # use serde_json::json;
 //! # #[cfg(feature = "json")]
+//! # use attohttpc::ResponseExt;
+//! # #[cfg(feature = "json")]
 //! # fn main() -> attohttpc::Result {
 //! let obj = json!({
 //!     "hello": "world",
@@ -85,7 +87,7 @@ mod tls;
 pub use crate::error::{Error, ErrorKind, InvalidResponseKind, Result};
 #[cfg(feature = "multipart")]
 pub use crate::multipart::{Multipart, MultipartBuilder, MultipartFile};
-pub use crate::parsing::{Response, ResponseReader};
+pub use crate::parsing::{Response, ResponseExt, ResponseReader};
 pub use crate::request::proxy::{ProxySettings, ProxySettingsBuilder};
 pub use crate::request::{body, PreparedRequest, RequestBuilder, RequestInspector, Session};
 #[cfg(feature = "charsets")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! // Check if the status is a 2XX code.
 //! if resp.is_success() {
 //!     // Consume the response body as text and print it.
-//!     println!("{}", resp.text()?);
+//!     println!("{}", resp.into_body().text()?);
 //! }
 //! # Ok(())
 //! # }

--- a/src/parsing/compressed_reader.rs
+++ b/src/parsing/compressed_reader.rs
@@ -105,7 +105,7 @@ mod tests {
     use super::have_encoding;
     use crate::parsing::response::parse_response;
     use crate::streams::BaseStream;
-    use crate::{PreparedRequest, ResponseExt};
+    use crate::PreparedRequest;
 
     #[test]
     #[cfg(feature = "flate2")]
@@ -159,7 +159,7 @@ mod tests {
 
         let sock = BaseStream::mock(buf);
         let response = parse_response(sock, &req).unwrap();
-        assert_eq!(response.text().unwrap(), "Hello world!!!!!!!!");
+        assert_eq!(response.into_body().text().unwrap(), "Hello world!!!!!!!!");
     }
 
     #[test]
@@ -182,7 +182,7 @@ mod tests {
 
         let sock = BaseStream::mock(buf);
         let response = parse_response(sock, &req).unwrap();
-        assert_eq!(response.text().unwrap(), "Hello world!!!!!!!!");
+        assert_eq!(response.into_body().text().unwrap(), "Hello world!!!!!!!!");
     }
 
     #[test]
@@ -206,7 +206,7 @@ mod tests {
         let sock = BaseStream::mock(buf);
         let response = parse_response(sock, &req).unwrap();
 
-        assert_eq!(response.text().unwrap(), "Hello world!!!!!!!!");
+        assert_eq!(response.into_body().text().unwrap(), "Hello world!!!!!!!!");
     }
 
     #[test]

--- a/src/parsing/compressed_reader.rs
+++ b/src/parsing/compressed_reader.rs
@@ -105,7 +105,7 @@ mod tests {
     use super::have_encoding;
     use crate::parsing::response::parse_response;
     use crate::streams::BaseStream;
-    use crate::PreparedRequest;
+    use crate::{PreparedRequest, ResponseExt};
 
     #[test]
     #[cfg(feature = "flate2")]
@@ -158,7 +158,7 @@ mod tests {
         let req = PreparedRequest::new(Method::GET, "http://google.ca");
 
         let sock = BaseStream::mock(buf);
-        let response = parse_response(sock, &req, req.url()).unwrap();
+        let response = parse_response(sock, &req).unwrap();
         assert_eq!(response.text().unwrap(), "Hello world!!!!!!!!");
     }
 
@@ -181,7 +181,7 @@ mod tests {
         let req = PreparedRequest::new(Method::GET, "http://google.ca");
 
         let sock = BaseStream::mock(buf);
-        let response = parse_response(sock, &req, req.url()).unwrap();
+        let response = parse_response(sock, &req).unwrap();
         assert_eq!(response.text().unwrap(), "Hello world!!!!!!!!");
     }
 
@@ -204,7 +204,7 @@ mod tests {
         let req = PreparedRequest::new(Method::GET, "http://google.ca");
 
         let sock = BaseStream::mock(buf);
-        let response = parse_response(sock, &req, req.url()).unwrap();
+        let response = parse_response(sock, &req).unwrap();
 
         assert_eq!(response.text().unwrap(), "Hello world!!!!!!!!");
     }
@@ -217,7 +217,7 @@ mod tests {
         let req = PreparedRequest::new(Method::GET, "http://google.ca");
         let sock = BaseStream::mock(buf.to_vec());
         // Fixed by the move from libflate to flate2
-        assert!(parse_response(sock, &req, req.url()).is_ok());
+        assert!(parse_response(sock, &req).is_ok());
     }
 
     #[test]
@@ -227,6 +227,6 @@ mod tests {
 
         let req = PreparedRequest::new(Method::HEAD, "http://google.ca");
         let sock = BaseStream::mock(buf.to_vec());
-        assert!(parse_response(sock, &req, req.url()).is_ok());
+        assert!(parse_response(sock, &req).is_ok());
     }
 }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -3,11 +3,13 @@ pub mod buffers;
 pub mod chunked_reader;
 pub mod compressed_reader;
 pub mod response;
+pub mod response_ext;
 pub mod response_reader;
 #[cfg(feature = "charsets")]
 pub mod text_reader;
 
 pub use self::response::{parse_response, Response};
+pub use self::response_ext::ResponseExt;
 pub use self::response_reader::ResponseReader;
 #[cfg(feature = "charsets")]
 pub use self::text_reader::TextReader;

--- a/src/parsing/response_ext.rs
+++ b/src/parsing/response_ext.rs
@@ -1,119 +1,33 @@
-#[cfg(feature = "charsets")]
-use std::io::BufReader;
-use std::io::Write;
-
-use http::response::Parts;
-
-#[cfg(feature = "charsets")]
-use crate::{charsets::Charset, parsing::TextReader};
-#[cfg(feature = "json")]
-use serde::de::DeserializeOwned;
+use http::response::{Parts, Response};
 
 use crate::header::HeaderMap;
-use crate::{ErrorKind, Response, ResponseReader, Result, StatusCode};
+use crate::{ErrorKind, Result, StatusCode};
 
-/// An extension trait adding helper methods to [`Response`].
+/// An extension trait adding helper methods to `Response`.
 pub trait ResponseExt: Sized + sealed::Sealed {
+    /// Body type of the response.
+    type Body;
+
     /// Checks if the status code of this `Response` was a success code.
     fn is_success(&self) -> bool;
 
     /// Returns error variant if the status code was not a success code.
     fn error_for_status(self) -> Result<Self>;
 
-    /// Split this `Response` into a tuple of `StatusCode`, `HeaderMap`, `ResponseReader`.
+    /// Split this `Response` into a tuple of `StatusCode`, `HeaderMap`, `Self::Body`.
     ///
     /// This method is useful to read the status code or headers after consuming the response.
-    fn split(self) -> (StatusCode, HeaderMap, ResponseReader);
-
-    /// Write the response to any object that implements `Write`.
-    fn write_to<W>(self, writer: W) -> Result<u64>
-    where
-        W: Write;
-
-    /// Read the response to a `Vec` of bytes.
-    fn bytes(self) -> Result<Vec<u8>>;
-
-    /// Read the response to a `String`.
-    ///
-    /// If the `charsets` feature is enabled, it will try to decode the response using
-    /// the encoding in the headers. If there's no encoding specified in the headers,
-    /// it will fall back to the default encoding, and if that's also not specified,
-    /// it will fall back to the default of ISO-8859-1.
-    ///
-    /// If the `charsets` feature is disabled, this method is the same as calling
-    /// `text_utf8`.
-    ///
-    /// Note that both conversions are lossy, i.e. they will not raise errors when
-    /// invalid data is encountered but output replacement characters instead.
-    fn text(self) -> Result<String>;
-
-    /// Read the response to a `String`, decoding with the given `Charset`.
-    ///
-    /// This will ignore the encoding from the response headers and the default encoding, if any.
-    ///
-    /// This method only exists when the `charsets` feature is enabled.
-    #[cfg(feature = "charsets")]
-    fn text_with(self, charset: Charset) -> Result<String>;
-
-    /// Create a `TextReader` from this `ResponseReader`.
-    ///
-    /// If the response headers contain charset information, that charset will be used to decode the body.
-    /// Otherwise, if a default encoding is set it will be used. If there is no default encoding, ISO-8859-1
-    /// will be used.
-    ///
-    /// This method only exists when the `charsets` feature is enabled.
-    #[cfg(feature = "charsets")]
-    fn text_reader(self) -> TextReader<BufReader<ResponseReader>>;
-
-    /// Create a `TextReader` from this `ResponseReader`, decoding with the given `Charset`.
-    ///
-    /// This will ignore the encoding from the response headers and the default encoding, if any.
-    ///
-    /// This method only exists when the `charsets` feature is enabled.
-    #[cfg(feature = "charsets")]
-    fn text_reader_with(self, charset: Charset) -> TextReader<BufReader<ResponseReader>>;
-
-    /// Read the response body to a String using the UTF-8 encoding.
-    ///
-    /// This method ignores headers and the default encoding.
-    ///
-    /// Note that is lossy, i.e. it will not raise errors when
-    /// invalid data is encountered but output replacement characters instead.
-    fn text_utf8(self) -> Result<String>;
-
-    /// Parse the response as a JSON object and return it.
-    ///
-    /// If the `charsets` feature is enabled, it will try to decode the response using
-    /// the encoding in the headers. If there's no encoding specified in the headers,
-    /// it will fall back to the default encoding, and if that's also not specified,
-    /// it will fall back to the default of ISO-8859-1.
-    ///
-    /// If the `charsets` feature is disabled, this method is the same as calling
-    /// `json_utf8`.
-    #[cfg(feature = "json")]
-    fn json<T>(self) -> Result<T>
-    where
-        T: DeserializeOwned;
-
-    /// Parse the response as a JSON object encoded in UTF-8.
-    ///
-    /// This method ignores headers and the default encoding.
-    ///
-    /// This method only exists when the `json` feature is enabled.
-    #[cfg(feature = "json")]
-    fn json_utf8<T>(self) -> Result<T>
-    where
-        T: DeserializeOwned;
+    fn split(self) -> (StatusCode, HeaderMap, Self::Body);
 }
 
 mod sealed {
-    use crate::Response;
-
     pub trait Sealed {}
-    impl Sealed for Response {}
+    impl<B> Sealed for http::Response<B> {}
 }
 
-impl ResponseExt for Response {
+impl<B> ResponseExt for Response<B> {
+    type Body = B;
+
     #[inline]
     fn is_success(&self) -> bool {
         self.status().is_success()
@@ -127,67 +41,8 @@ impl ResponseExt for Response {
         }
     }
 
-    #[inline]
-    fn split(self) -> (StatusCode, HeaderMap, ResponseReader) {
+    fn split(self) -> (StatusCode, HeaderMap, Self::Body) {
         let (Parts { status, headers, .. }, body) = self.into_parts();
         (status, headers, body)
-    }
-
-    #[inline]
-    fn write_to<W>(self, writer: W) -> Result<u64>
-    where
-        W: Write,
-    {
-        self.into_body().write_to(writer)
-    }
-
-    #[inline]
-    fn bytes(self) -> Result<Vec<u8>> {
-        self.into_body().bytes()
-    }
-
-    #[inline]
-    fn text(self) -> Result<String> {
-        self.into_body().text()
-    }
-
-    #[cfg(feature = "charsets")]
-    #[inline]
-    fn text_with(self, charset: Charset) -> Result<String> {
-        self.into_body().text_with(charset)
-    }
-
-    #[cfg(feature = "charsets")]
-    fn text_reader(self) -> TextReader<BufReader<ResponseReader>> {
-        self.into_body().text_reader()
-    }
-
-    #[cfg(feature = "charsets")]
-    #[inline]
-    fn text_reader_with(self, charset: Charset) -> TextReader<BufReader<ResponseReader>> {
-        self.into_body().text_reader_with(charset)
-    }
-
-    #[inline]
-    fn text_utf8(self) -> Result<String> {
-        self.into_body().text_utf8()
-    }
-
-    #[cfg(feature = "json")]
-    #[inline]
-    fn json<T>(self) -> Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        self.into_body().json()
-    }
-
-    #[cfg(feature = "json")]
-    #[inline]
-    fn json_utf8<T>(self) -> Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        self.into_body().json_utf8()
     }
 }

--- a/src/parsing/response_ext.rs
+++ b/src/parsing/response_ext.rs
@@ -1,0 +1,193 @@
+#[cfg(feature = "charsets")]
+use std::io::BufReader;
+use std::io::Write;
+
+use http::response::Parts;
+
+#[cfg(feature = "charsets")]
+use crate::{charsets::Charset, parsing::TextReader};
+#[cfg(feature = "json")]
+use serde::de::DeserializeOwned;
+
+use crate::header::HeaderMap;
+use crate::{ErrorKind, Response, ResponseReader, Result, StatusCode};
+
+/// An extension trait adding helper methods to [`Response`].
+pub trait ResponseExt: Sized + sealed::Sealed {
+    /// Checks if the status code of this `Response` was a success code.
+    fn is_success(&self) -> bool;
+
+    /// Returns error variant if the status code was not a success code.
+    fn error_for_status(self) -> Result<Self>;
+
+    /// Split this `Response` into a tuple of `StatusCode`, `HeaderMap`, `ResponseReader`.
+    ///
+    /// This method is useful to read the status code or headers after consuming the response.
+    fn split(self) -> (StatusCode, HeaderMap, ResponseReader);
+
+    /// Write the response to any object that implements `Write`.
+    fn write_to<W>(self, writer: W) -> Result<u64>
+    where
+        W: Write;
+
+    /// Read the response to a `Vec` of bytes.
+    fn bytes(self) -> Result<Vec<u8>>;
+
+    /// Read the response to a `String`.
+    ///
+    /// If the `charsets` feature is enabled, it will try to decode the response using
+    /// the encoding in the headers. If there's no encoding specified in the headers,
+    /// it will fall back to the default encoding, and if that's also not specified,
+    /// it will fall back to the default of ISO-8859-1.
+    ///
+    /// If the `charsets` feature is disabled, this method is the same as calling
+    /// `text_utf8`.
+    ///
+    /// Note that both conversions are lossy, i.e. they will not raise errors when
+    /// invalid data is encountered but output replacement characters instead.
+    fn text(self) -> Result<String>;
+
+    /// Read the response to a `String`, decoding with the given `Charset`.
+    ///
+    /// This will ignore the encoding from the response headers and the default encoding, if any.
+    ///
+    /// This method only exists when the `charsets` feature is enabled.
+    #[cfg(feature = "charsets")]
+    fn text_with(self, charset: Charset) -> Result<String>;
+
+    /// Create a `TextReader` from this `ResponseReader`.
+    ///
+    /// If the response headers contain charset information, that charset will be used to decode the body.
+    /// Otherwise, if a default encoding is set it will be used. If there is no default encoding, ISO-8859-1
+    /// will be used.
+    ///
+    /// This method only exists when the `charsets` feature is enabled.
+    #[cfg(feature = "charsets")]
+    fn text_reader(self) -> TextReader<BufReader<ResponseReader>>;
+
+    /// Create a `TextReader` from this `ResponseReader`, decoding with the given `Charset`.
+    ///
+    /// This will ignore the encoding from the response headers and the default encoding, if any.
+    ///
+    /// This method only exists when the `charsets` feature is enabled.
+    #[cfg(feature = "charsets")]
+    fn text_reader_with(self, charset: Charset) -> TextReader<BufReader<ResponseReader>>;
+
+    /// Read the response body to a String using the UTF-8 encoding.
+    ///
+    /// This method ignores headers and the default encoding.
+    ///
+    /// Note that is lossy, i.e. it will not raise errors when
+    /// invalid data is encountered but output replacement characters instead.
+    fn text_utf8(self) -> Result<String>;
+
+    /// Parse the response as a JSON object and return it.
+    ///
+    /// If the `charsets` feature is enabled, it will try to decode the response using
+    /// the encoding in the headers. If there's no encoding specified in the headers,
+    /// it will fall back to the default encoding, and if that's also not specified,
+    /// it will fall back to the default of ISO-8859-1.
+    ///
+    /// If the `charsets` feature is disabled, this method is the same as calling
+    /// `json_utf8`.
+    #[cfg(feature = "json")]
+    fn json<T>(self) -> Result<T>
+    where
+        T: DeserializeOwned;
+
+    /// Parse the response as a JSON object encoded in UTF-8.
+    ///
+    /// This method ignores headers and the default encoding.
+    ///
+    /// This method only exists when the `json` feature is enabled.
+    #[cfg(feature = "json")]
+    fn json_utf8<T>(self) -> Result<T>
+    where
+        T: DeserializeOwned;
+}
+
+mod sealed {
+    use crate::Response;
+
+    pub trait Sealed {}
+    impl Sealed for Response {}
+}
+
+impl ResponseExt for Response {
+    #[inline]
+    fn is_success(&self) -> bool {
+        self.status().is_success()
+    }
+
+    fn error_for_status(self) -> Result<Self> {
+        if self.is_success() {
+            Ok(self)
+        } else {
+            Err(ErrorKind::StatusCode(self.status()).into())
+        }
+    }
+
+    #[inline]
+    fn split(self) -> (StatusCode, HeaderMap, ResponseReader) {
+        let (Parts { status, headers, .. }, body) = self.into_parts();
+        (status, headers, body)
+    }
+
+    #[inline]
+    fn write_to<W>(self, writer: W) -> Result<u64>
+    where
+        W: Write,
+    {
+        self.into_body().write_to(writer)
+    }
+
+    #[inline]
+    fn bytes(self) -> Result<Vec<u8>> {
+        self.into_body().bytes()
+    }
+
+    #[inline]
+    fn text(self) -> Result<String> {
+        self.into_body().text()
+    }
+
+    #[cfg(feature = "charsets")]
+    #[inline]
+    fn text_with(self, charset: Charset) -> Result<String> {
+        self.into_body().text_with(charset)
+    }
+
+    #[cfg(feature = "charsets")]
+    fn text_reader(self) -> TextReader<BufReader<ResponseReader>> {
+        self.into_body().text_reader()
+    }
+
+    #[cfg(feature = "charsets")]
+    #[inline]
+    fn text_reader_with(self, charset: Charset) -> TextReader<BufReader<ResponseReader>> {
+        self.into_body().text_reader_with(charset)
+    }
+
+    #[inline]
+    fn text_utf8(self) -> Result<String> {
+        self.into_body().text_utf8()
+    }
+
+    #[cfg(feature = "json")]
+    #[inline]
+    fn json<T>(self) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        self.into_body().json()
+    }
+
+    #[cfg(feature = "json")]
+    #[inline]
+    fn json_utf8<T>(self) -> Result<T>
+    where
+        T: DeserializeOwned,
+    {
+        self.into_body().json_utf8()
+    }
+}

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -228,7 +228,7 @@ impl<B: Body> PreparedRequest<B> {
             let mut stream = BaseStream::connect(&info)?;
 
             self.write_request(&mut stream, &url, proxy.as_ref())?;
-            let resp = parse_response(stream, self, &url)?;
+            let resp = parse_response(stream, self)?;
 
             debug!("status code {}", resp.status().as_u16());
 

--- a/tests/test_multipart.rs
+++ b/tests/test_multipart.rs
@@ -8,8 +8,6 @@ use multipart::server::Multipart;
 use tokio::runtime::Builder;
 use warp::Filter;
 
-use attohttpc::ResponseExt;
-
 fn start_server() -> (u16, Receiver<Option<String>>) {
     let (send, recv) = sync_channel(1);
     let rt = Builder::new_multi_thread().enable_io().enable_time().build().unwrap();
@@ -94,6 +92,7 @@ fn test_multipart_default() -> attohttpc::Result<()> {
     attohttpc::post(format!("http://localhost:{port}/multipart"))
         .body(form)
         .send()?
+        .into_body()
         .text()?;
 
     if let Some(err) = recv.recv().unwrap() {

--- a/tests/test_multipart.rs
+++ b/tests/test_multipart.rs
@@ -8,6 +8,8 @@ use multipart::server::Multipart;
 use tokio::runtime::Builder;
 use warp::Filter;
 
+use attohttpc::ResponseExt;
+
 fn start_server() -> (u16, Receiver<Option<String>>) {
     let (send, recv) = sync_channel(1);
     let rt = Builder::new_multi_thread().enable_io().enable_time().build().unwrap();

--- a/tests/test_proxy.rs
+++ b/tests/test_proxy.rs
@@ -2,8 +2,6 @@ mod tools;
 
 use url::Url;
 
-use attohttpc::ResponseExt;
-
 #[tokio::test(flavor = "multi_thread")]
 async fn test_http_url_with_http_proxy() -> Result<(), anyhow::Error> {
     let remote_port = tools::start_hello_world_server(false).await?;
@@ -22,7 +20,7 @@ async fn test_http_url_with_http_proxy() -> Result<(), anyhow::Error> {
 
     let resp = sess.get(remote_url).danger_accept_invalid_certs(true).send().unwrap();
 
-    assert_eq!(resp.text().unwrap(), "hello");
+    assert_eq!(resp.into_body().text().unwrap(), "hello");
 
     Ok(())
 }
@@ -46,7 +44,7 @@ async fn test_http_url_with_https_proxy() -> Result<(), anyhow::Error> {
 
     let resp = sess.get(remote_url).danger_accept_invalid_certs(true).send().unwrap();
 
-    assert_eq!(resp.text().unwrap(), "hello");
+    assert_eq!(resp.into_body().text().unwrap(), "hello");
 
     Ok(())
 }
@@ -70,7 +68,7 @@ async fn test_https_url_with_http_proxy() -> Result<(), anyhow::Error> {
 
     let resp = sess.get(remote_url).danger_accept_invalid_certs(true).send().unwrap();
 
-    assert_eq!(resp.text().unwrap(), "hello");
+    assert_eq!(resp.into_body().text().unwrap(), "hello");
 
     Ok(())
 }
@@ -95,7 +93,7 @@ async fn test_https_url_with_https_proxy() -> Result<(), anyhow::Error> {
     let resp = sess.get(remote_url).danger_accept_invalid_certs(true).send().unwrap();
 
     assert_eq!(resp.status().as_u16(), 200);
-    assert_eq!(resp.text().unwrap(), "hello");
+    assert_eq!(resp.into_body().text().unwrap(), "hello");
 
     Ok(())
 }
@@ -120,7 +118,7 @@ async fn test_http_url_with_http_proxy_refusal() -> Result<(), anyhow::Error> {
         .unwrap();
 
     assert_eq!(resp.status().as_u16(), 400);
-    assert_eq!(resp.text().unwrap(), "bad request");
+    assert_eq!(resp.into_body().text().unwrap(), "bad request");
 
     Ok(())
 }
@@ -173,7 +171,7 @@ async fn test_http_url_with_https_proxy_refusal() -> Result<(), anyhow::Error> {
         .unwrap();
 
     assert_eq!(resp.status().as_u16(), 400);
-    assert_eq!(resp.text().unwrap(), "bad request");
+    assert_eq!(resp.into_body().text().unwrap(), "bad request");
 
     Ok(())
 }

--- a/tests/test_proxy.rs
+++ b/tests/test_proxy.rs
@@ -2,6 +2,8 @@ mod tools;
 
 use url::Url;
 
+use attohttpc::ResponseExt;
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_http_url_with_http_proxy() -> Result<(), anyhow::Error> {
     let remote_port = tools::start_hello_world_server(false).await?;


### PR DESCRIPTION
This is like a RFC rather than a proposal. Uses `http::Response` type to describe a response type instead of defining a own type. When users are familiar with `http` crate which is one of the famous  libraries for HTTP types, users can use it intuitively. And `attohttpc` can free from maintaining the response type ourselves by delegating it like header types. The first commit changes to use `http::Response` and moves the existing APIs to `ResponseExt` trait which is newly introduced, except for the following two APIs. By this changes, The `Write` trait implementation for `Response` is dropped as Rust's trait rule, and the ability to get `url` from `Response` is removed as it is not provided by `http` crate. I think the both of them might be small backward as they have workaround which is easily achieved. The second commit removes APIs which are simply passed to `ResponseReader`. These APIs are actually for the body, but since they are existing in `Response` type, it is possible to be misleading as it is for the entire response message.