### PR TITLE
Add rustls 'tls12' feature to continue to support TLS 1.2 connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rustls-native-certs = { version = "0.7", optional = true }
 rustls-opt-dep = { package = "rustls", version = "0.23.0", default-features = false, features = [
     "ring",
     "std",
+    "tls12",
 ], optional = true }
 serde = { version = "1.0.143", optional = true }
 serde_json = { version = "1.0.83", optional = true }


### PR DESCRIPTION
Closes #176 

Info
-----
* The recent upgrade of the `rustls` dependency inadvertently removed the default feature `tls12`
* The result is that the latest version of `attohttpc` doesn't support TLS 1.2 connections using Rustls as the underlying TLS provider.

Changes
-----
* Added `tls12` to the list of re-enabled features in `Cargo.toml`

Tested
-----
* Locally verified that having the `tls12` feature enabled allows connections to `registry.npmjs.org` (while those connections fail using the latest attohttpc version `0.28.1`)