### PR TITLE
Move `tokio-rustls` to `[dev-dependencies]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ rustls-opt-dep = { package = "rustls", version = "0.23.22", default-features = f
 serde = { version = "1.0.143", optional = true }
 serde_json = { version = "1.0.83", optional = true }
 serde_urlencoded = { version = "0.7.1", optional = true }
-tokio-rustls = "0.26.1"
 url = "2.2.2"
 webpki-roots = { version = "0.26.8", optional = true }
 
@@ -62,6 +61,7 @@ rustls-opt-dep = { package = "rustls", version = "0.23.22", default-features = f
 ] }
 rustls-pemfile = "2"
 tokio = { version = "1.20.1", features = ["full"] }
+tokio-rustls = "0.26.1"
 
 [features]
 basic-auth = ["base64"]


### PR DESCRIPTION
This was added to `[dependencies]` in #178, but I assume that was an accident because it's only used in tests.