### PR TITLE
fix: reduce expensive clones of BaseSettings

### DIFF
--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -431,7 +431,6 @@ impl<B: Body> RequestBuilder<B> {
 
     /// Create a `PreparedRequest` from this `RequestBuilder`.
     pub fn try_prepare(self) -> Result<PreparedRequest<B>> {
-        dbg!(&self.headers);
         let mut prepped = PreparedRequest {
             url: self.url,
             method: self.method,
@@ -516,8 +515,6 @@ fn test_accept_invalid_certs_disabled_by_default() {
 
 #[cfg(test)]
 mod tests {
-    use crate::request::header_append;
-
     use super::*;
     use http::header::HeaderMap;
 

--- a/src/request/builder.rs
+++ b/src/request/builder.rs
@@ -404,7 +404,8 @@ impl<B> RequestBuilder<B> {
     /// Use this setting with care. This will accept TLS certificates that do not match
     /// the hostname.
     pub fn danger_accept_invalid_hostnames(mut self, accept_invalid_hostnames: bool) -> Self {
-        self.base_settings.set_accept_invalid_hostnames(accept_invalid_hostnames);
+        self.base_settings
+            .set_accept_invalid_hostnames(accept_invalid_hostnames);
         self
     }
 

--- a/src/request/session.rs
+++ b/src/request/session.rs
@@ -14,7 +14,9 @@ use crate::tls::Certificate;
 
 /// `Session` is a type that can carry settings over multiple requests. The settings applied to the
 /// `Session` are applied to every request created from this `Session`.
-#[derive(Debug, Default)]
+///
+/// `Session` can be cloned cheaply and sent to other threads as it uses [std::sync::Arc] internally.
+#[derive(Clone, Debug, Default)]
 pub struct Session {
     base_settings: Arc<BaseSettings>,
 }
@@ -95,7 +97,7 @@ impl Session {
     // Settings
     //
 
-    /// Modify a header for this `Request`.
+    /// Modify a header for this `Session`.
     ///
     /// If the header is already present, the value will be replaced. If you wish to append a new header,
     /// use `header_append`.
@@ -111,9 +113,9 @@ impl Session {
         self.try_header(header, value).expect("invalid header value");
     }
 
-    /// Append a new header for this `Request`.
+    /// Append a new header for this `Session`.
     ///
-    /// The new header is always appended to the request, even if the header already exists.
+    /// The new header is always appended to the headers, even if the header already exists.
     ///
     /// # Panics
     /// This method will panic if the value is invalid.
@@ -126,7 +128,7 @@ impl Session {
         self.try_header_append(header, value).expect("invalid header value");
     }
 
-    /// Modify a header for this `Request`.
+    /// Modify a header for this `Session`.
     ///
     /// If the header is already present, the value will be replaced. If you wish to append a new header,
     /// use `header_append`.
@@ -139,9 +141,9 @@ impl Session {
         self.base_settings.try_header(header, value)
     }
 
-    /// Append a new header to this `Request`.
+    /// Append a new header to this `Session`.
     ///
-    /// The new header is always appended to the `Request`, even if the header already exists.
+    /// The new header is always appended to the headers, even if the header already exists.
     pub fn try_header_append<H, V>(&mut self, header: H, value: V) -> Result<()>
     where
         H: IntoHeaderName,
@@ -151,74 +153,74 @@ impl Session {
         self.base_settings.try_header_append(header, value)
     }
 
-    /// Set the maximum number of headers accepted in responses to this request.
+    /// Set the maximum number of headers accepted in responses to requests created from this `Session`.
     ///
     /// The default is 100.
     pub fn max_headers(&mut self, max_headers: usize) {
         self.base_settings.set_max_headers(max_headers);
     }
 
-    /// Set the maximum number of redirections this `Request` can perform.
+    /// Set the maximum number of redirections the requests created from this `Session` can perform.
     ///
     /// The default is 5.
     pub fn max_redirections(&mut self, max_redirections: u32) {
         self.base_settings.set_max_redirections(max_redirections);
     }
 
-    /// Sets if this `Request` should follow redirects, 3xx codes.
+    /// Sets if requests created from this `Session` should follow redirects, 3xx codes.
     ///
     /// This value defaults to true.
     pub fn follow_redirects(&mut self, follow_redirects: bool) {
         self.base_settings.set_follow_redirects(follow_redirects);
     }
 
-    /// Sets a connect timeout for this request.
+    /// Sets a connect timeout for requests created from this `Session`.
     ///
     /// The default is 30 seconds.
     pub fn connect_timeout(&mut self, connect_timeout: Duration) {
         self.base_settings.set_connect_timeout(connect_timeout);
     }
 
-    /// Sets a read timeout for this request.
+    /// Sets a read timeout for requests created from this `Session`.
     ///
     /// The default is 30 seconds.
     pub fn read_timeout(&mut self, read_timeout: Duration) {
         self.base_settings.set_read_tmeout(read_timeout);
     }
 
-    /// Sets a timeout for the whole request.
+    /// Sets a timeout for the maximum duration of requests created from this `Session`.
     ///
     /// Applies after a TCP connection is established. Defaults to no timeout.
     pub fn timeout(&mut self, timeout: Duration) {
         self.base_settings.set_timeout(Some(timeout));
     }
 
-    /// Sets the proxy settigns for this request.
+    /// Sets the proxy settigns for requests created from this `Session`.
     ///
     /// If left untouched, the defaults are to use system proxy settings found in environment variables.
     pub fn proxy_settings(&mut self, proxy_settings: ProxySettings) {
         self.base_settings.set_proxy_settings(proxy_settings);
     }
 
-    /// Set the default charset to use while parsing the response of this `Request`.
+    /// Set the default charset to use while parsing the responses of requests created from this `Session`.
     ///
-    /// If the response does not say which charset it uses, this charset will be used to decode the request.
+    /// If the response does not say which charset it uses, this charset will be used to decode the requests.
     /// This value defaults to `None`, in which case ISO-8859-1 is used.
     #[cfg(feature = "charsets")]
     pub fn default_charset(&mut self, default_charset: Option<Charset>) {
         self.base_settings.set_default_charset(default_charset);
     }
 
-    /// Sets if this `Request` will announce that it accepts compression.
+    /// Sets if requests created from this `Session` will announce that they accept compression.
     ///
-    /// This value defaults to true. Note that this only lets the browser know that this `Request` supports
+    /// This value defaults to true. Note that this only lets the browser know that the requests support
     /// compression, the server might choose not to compress the content.
     #[cfg(feature = "flate2")]
     pub fn allow_compression(&mut self, allow_compression: bool) {
         self.base_settings.set_allow_compression(allow_compression);
     }
 
-    /// Sets if this `Request` will accept invalid TLS certificates.
+    /// Sets if requests created from this `Session` will accept invalid TLS certificates.
     ///
     /// Accepting invalid certificates implies that invalid hostnames are accepted
     /// as well.
@@ -233,7 +235,7 @@ impl Session {
         self.base_settings.set_accept_invalid_certs(accept_invalid_certs);
     }
 
-    /// Sets if this `Request` will accept an invalid hostname in a TLS certificate.
+    /// Sets if requests created from this `Session` will accept an invalid hostname in a TLS certificate.
     ///
     /// The default value is `false`.
     ///
@@ -245,7 +247,7 @@ impl Session {
             .set_accept_invalid_hostnames(accept_invalid_hostnames);
     }
 
-    /// Adds a root certificate that will be trusted.
+    /// Adds a root certificate that will be trusted by requests created from this `Session`.
     pub fn add_root_certificate(&mut self, cert: Certificate) {
         self.base_settings.add_root_certificate(cert);
     }

--- a/src/request/session.rs
+++ b/src/request/session.rs
@@ -241,7 +241,8 @@ impl Session {
     /// Use this setting with care. This will accept TLS certificates that do not match
     /// the hostname.
     pub fn danger_accept_invalid_hostnames(&mut self, accept_invalid_hostnames: bool) {
-        self.base_settings.set_accept_invalid_hostnames(accept_invalid_hostnames);
+        self.base_settings
+            .set_accept_invalid_hostnames(accept_invalid_hostnames);
     }
 
     /// Adds a root certificate that will be trusted.

--- a/src/request/settings.rs
+++ b/src/request/settings.rs
@@ -6,13 +6,12 @@ use http::{HeaderMap, HeaderValue};
 
 #[cfg(feature = "charsets")]
 use crate::charsets::Charset;
+use crate::error::{Error, Result};
 use crate::request::proxy::ProxySettings;
 use crate::skip_debug::SkipDebug;
 use crate::tls::Certificate;
-use crate::error::{Error, Result};
 
 use super::{header_append, header_insert};
-
 
 #[derive(Clone, Debug)]
 pub struct BaseSettings {
@@ -56,7 +55,7 @@ impl Default for BaseSettings {
     }
 }
 
-macro_rules! basic_setter  {
+macro_rules! basic_setter {
     ($name:ident, $param:ident, $type:ty) => {
         #[inline]
         pub(crate) fn $name(self: &mut Arc<Self>, $param: $type) {
@@ -65,13 +64,12 @@ macro_rules! basic_setter  {
     };
 }
 
-
 impl BaseSettings {
     #[inline]
     pub(crate) fn headers_mut(self: &mut Arc<Self>) -> &mut HeaderMap {
         &mut Arc::make_mut(self).headers
     }
-    
+
     #[inline]
     pub(crate) fn try_header<H, V>(self: &mut Arc<Self>, header: H, value: V) -> Result<()>
     where
@@ -111,4 +109,3 @@ impl BaseSettings {
     #[cfg(feature = "flate2")]
     basic_setter!(set_allow_compression, allow_compression, bool);
 }
-

--- a/src/request/settings.rs
+++ b/src/request/settings.rs
@@ -66,7 +66,7 @@ macro_rules! basic_setter {
 
 impl BaseSettings {
     #[inline]
-    pub(crate) fn headers_mut(self: &mut Arc<Self>) -> &mut HeaderMap {
+    fn headers_mut(self: &mut Arc<Self>) -> &mut HeaderMap {
         &mut Arc::make_mut(self).headers
     }
 
@@ -77,7 +77,7 @@ impl BaseSettings {
         V: TryInto<HeaderValue>,
         Error: From<V::Error>,
     {
-        header_insert(&mut Arc::make_mut(self).headers, header, value)
+        header_insert(self.headers_mut(), header, value)
     }
 
     #[inline]
@@ -87,7 +87,7 @@ impl BaseSettings {
         V: TryInto<HeaderValue>,
         Error: From<V::Error>,
     {
-        header_append(&mut Arc::make_mut(self).headers, header, value)
+        header_append(self.headers_mut(), header, value)
     }
 
     #[inline]


### PR DESCRIPTION
Use `Arc`'s clone-on-write capabilities to only clone data when absolutely necessary.