### PR TITLE
Add feature flags `tls-rustls-webpki-roots-ring` and `tls-rustls-native-roots-ring` for rustls ring backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ mime_guess = { version = "2.0.5", optional = true }
 native-tls = { version = "0.2.10", optional = true }
 rand = { version = "0.9.0", optional = true }
 rustls-native-certs = { version = "0.8.1", optional = true }
-rustls = { version = "0.23.22", optional = true }
+rustls = { version = "0.23.22", default-features = false, optional = true }
 serde = { version = "1.0.143", optional = true }
 serde_json = { version = "1.0.83", optional = true }
 serde_urlencoded = { version = "0.7.1", optional = true }
@@ -65,6 +65,8 @@ multipart-form = ["mime", "mime_guess", "rand"]
 tls-native = ["native-tls"]
 tls-rustls-webpki-roots = ["__rustls", "webpki-roots"]
 tls-rustls-native-roots = ["__rustls", "rustls-native-certs"]
+tls-rustls-webpki-roots-ring = ["__rustls-ring", "webpki-roots"]
+tls-rustls-native-roots-ring = ["__rustls-ring", "rustls-native-certs"]
 # This feature depends on tls-native
 tls-native-vendored = ["native-tls/vendored"]
 # These features are provided for backwards compatibility
@@ -73,7 +75,8 @@ rustls = ["tls-rustls-webpki-roots"]
 tls-rustls = ["tls-rustls-webpki-roots"]
 tls-vendored = ["tls-native-vendored"]
 # Internal feature used to indicate rustls support
-__rustls = ["dep:rustls"]
+__rustls = ["dep:rustls", "rustls/default"]
+__rustls-ring = ["rustls/ring", "rustls/std", "rustls/tls12"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tests/test_proxy.rs
+++ b/tests/test_proxy.rs
@@ -1,3 +1,5 @@
+#![cfg(not(any(feature = "tls-rustls-webpki-roots-ring", feature = "tls-rustls-native-roots-ring")))]
+
 mod tools;
 
 use url::Url;

--- a/tools/tests.bash
+++ b/tools/tests.bash
@@ -33,3 +33,5 @@ testwrap --no-default-features --features tls-native
 testwrap --no-default-features --features tls-native,tls-native-vendored
 testwrap --no-default-features --features tls-rustls-webpki-roots
 testwrap --no-default-features --features tls-rustls-native-roots
+testwrap --no-default-features --features tls-rustls-webpki-roots-ring
+testwrap --no-default-features --features tls-rustls-native-roots-ring


### PR DESCRIPTION
I'm unable to build `attohttpc`-dependent source code into WASM components due to missing headers while compiling `aws-lc-sys`. Switching to `ring` backend fixes this issue.