### PR TITLE
Add a feature flag for disabling additional threads during initial connection and for timeout handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ default = ["compress", "tls-native"]
 form = ["serde", "serde_urlencoded"]
 json = ["serde", "serde_json"]
 multipart-form = ["mime", "mime_guess", "rand"]
+single-threaded = []
 # The following TLS features are mutually exclusive
 tls-native = ["native-tls"]
 tls-rustls-webpki-roots = ["__rustls", "webpki-roots"]

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -2,6 +2,7 @@
 use std::io::Cursor;
 use std::io::{self, Read, Write};
 #[cfg(not(windows))]
+#[cfg(not(feature = "single-threaded"))]
 use std::net::Shutdown;
 use std::net::TcpStream;
 #[cfg(windows)]
@@ -10,6 +11,7 @@ use std::os::{
     windows::{io::AsRawSocket, raw::SOCKET},
 };
 use std::sync::mpsc;
+#[cfg(not(feature = "single-threaded"))]
 use std::thread;
 use std::time::Instant;
 
@@ -132,6 +134,7 @@ impl BaseStream {
     fn connect_tcp(host: &Host<&str>, port: u16, info: &ConnectInfo) -> Result<(TcpStream, Option<mpsc::Sender<()>>)> {
         let stream = happy::connect(host, port, info.base_settings.connect_timeout, info.deadline)?;
         stream.set_read_timeout(Some(info.base_settings.read_timeout))?;
+        #[cfg(not(feature = "single-threaded"))]
         let timeout = info
             .deadline
             .map(|deadline| -> Result<mpsc::Sender<()>> {
@@ -167,6 +170,8 @@ impl BaseStream {
                 Ok(tx)
             })
             .transpose()?;
+        #[cfg(feature = "single-threaded")]
+        let timeout: Option<mpsc::Sender<()>> = None;
         Ok((stream, timeout))
     }
 

--- a/tests/test_timeout.rs
+++ b/tests/test_timeout.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "single-threaded"))]
+
 use std::io;
 use std::net::TcpListener;
 use std::thread;

--- a/tools/tests.bash
+++ b/tools/tests.bash
@@ -29,6 +29,7 @@ testwrap --no-default-features --features compress-zlib-ng
 testwrap --no-default-features --features form
 testwrap --no-default-features --features multipart-form
 testwrap --no-default-features --features json
+testwrap --no-default-features --features single-threaded
 testwrap --no-default-features --features tls-native
 testwrap --no-default-features --features tls-native,tls-native-vendored
 testwrap --no-default-features --features tls-rustls-webpki-roots


### PR DESCRIPTION
This is useful for `wasm32-*` targets, which do not allow spawning additional threads.