### PR TITLE
Support WASI platforms

### DIFF
--- a/src/streams.rs
+++ b/src/streams.rs
@@ -131,6 +131,7 @@ impl BaseStream {
 
     fn connect_tcp(host: &Host<&str>, port: u16, info: &ConnectInfo) -> Result<(TcpStream, Option<mpsc::Sender<()>>)> {
         let stream = happy::connect(host, port, info.base_settings.connect_timeout, info.deadline)?;
+        #[cfg(not(target_os = "wasi"))]
         stream.set_read_timeout(Some(info.base_settings.read_timeout))?;
         let timeout = info
             .deadline


### PR DESCRIPTION
`TcpStream::set_read_timeout` is currently unsupported in `wasi-libc`, we should not set this for now.