### PR TITLE
fix: remove deprecated `rustls` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ tls-rustls-native-roots-ring = ["__rustls-ring", "rustls-native-certs"]
 tls-native-vendored = ["native-tls/vendored"]
 # These features are provided for backwards compatibility
 tls = ["tls-native"]
-rustls = ["tls-rustls-webpki-roots"]
 tls-rustls = ["tls-rustls-webpki-roots"]
 tls-vendored = ["tls-native-vendored"]
 # Internal feature used to indicate rustls support


### PR DESCRIPTION
When either of `tls-rustls-webpki-roots-ring` or `tls-rustls-native-roots-ring` are enabled, cargo pulls in `aws-lc-rs` too, presumably due to `__rustls-ring` depending on `rustls/*` features (and for some reason cargo assumes that we are also depending on `rustls` feature along with `rustls` dependency). I could not find any other way around it.